### PR TITLE
User can specify key manticore options which are loaded with sensible defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'

--- a/MUI/build.gradle
+++ b/MUI/build.gradle
@@ -114,7 +114,7 @@ task install() {
 // Code style formatting
 spotless {
     // optional: limit format enforcement to just the files changed by this feature branch
-    ratchetFrom 'origin/main'
+    // ratchetFrom 'origin/main'
 
     format 'misc', {
         // define the files to apply `misc` to

--- a/MUI/src/main/java/mui/MUILogProvider.java
+++ b/MUI/src/main/java/mui/MUILogProvider.java
@@ -34,9 +34,9 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		logPanel.add(logTabPane);
 	}
 
-	public void runMUI(String[] manticoreArgs) {
+	public void runMUI(String manticoreExePath, HashMap<String, Object> formOptions) {
 		MUILogContentComponent newTabContent = new MUILogContentComponent();
-		newTabContent.MUIInstance.callProc(manticoreArgs);
+		newTabContent.MUIInstance.callProc(manticoreExePath, formOptions);
 		logTabPane.add(
 			ZonedDateTime.now(ZoneId.systemDefault())
 					.format(DateTimeFormatter.ofPattern("HH:mm:ss")),

--- a/MUI/src/main/java/mui/MUILogProvider.java
+++ b/MUI/src/main/java/mui/MUILogProvider.java
@@ -40,11 +40,11 @@ public class MUILogProvider extends ComponentProviderAdapter {
 	}
 
 	public void runMUI(String manticoreExePath, String programPath,
-			HashMap<String, JTextField> formOptions) {
+			HashMap<String, JTextField> formOptions, String moreArgs) {
 		MUILogContentComponent newTabContent = new MUILogContentComponent();
 
 		newTabContent.MUIInstance
-				.callProc(buildCommand(manticoreExePath, programPath, formOptions));
+				.callProc(buildCommand(manticoreExePath, programPath, formOptions, moreArgs));
 		logTabPane.add(
 			ZonedDateTime.now(ZoneId.systemDefault())
 					.format(DateTimeFormatter.ofPattern("HH:mm:ss")),
@@ -55,7 +55,7 @@ public class MUILogProvider extends ComponentProviderAdapter {
 	}
 
 	public String[] buildCommand(String manticoreExePath, String programPath,
-			HashMap<String, JTextField> formOptions) {
+			HashMap<String, JTextField> formOptions, String moreArgs) {
 		ArrayList<String> f_command = new ArrayList<String>();
 		f_command.add(manticoreExePath);
 		String[] argv = parseCommand(formOptions.get("argv").getText());
@@ -67,6 +67,8 @@ public class MUILogProvider extends ComponentProviderAdapter {
 				f_command.add(arg);
 			}
 		}
+
+		f_command.addAll(Arrays.asList(parseCommand(moreArgs)));
 
 		f_command.add(programPath);
 		f_command.addAll(Arrays.asList(argv));

--- a/MUI/src/main/java/mui/MUILogProvider.java
+++ b/MUI/src/main/java/mui/MUILogProvider.java
@@ -39,10 +39,12 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		logPanel.add(logTabPane);
 	}
 
-	public void runMUI(String manticoreExePath, String programPath, HashMap<String, JTextField> formOptions) {
+	public void runMUI(String manticoreExePath, String programPath,
+			HashMap<String, JTextField> formOptions) {
 		MUILogContentComponent newTabContent = new MUILogContentComponent();
-	
-		newTabContent.MUIInstance.callProc(buildCommand(manticoreExePath, programPath, formOptions));
+
+		newTabContent.MUIInstance
+				.callProc(buildCommand(manticoreExePath, programPath, formOptions));
 		logTabPane.add(
 			ZonedDateTime.now(ZoneId.systemDefault())
 					.format(DateTimeFormatter.ofPattern("HH:mm:ss")),
@@ -51,25 +53,27 @@ public class MUILogProvider extends ComponentProviderAdapter {
 			logTabPane.getTabCount() - 1, new MUILogTabComponent(logTabPane, this));
 		logTabPane.setSelectedIndex(logTabPane.getTabCount() - 1);
 	}
-	
-	public String[] buildCommand(String manticoreExePath, String programPath, HashMap<String, JTextField> formOptions) {
+
+	public String[] buildCommand(String manticoreExePath, String programPath,
+			HashMap<String, JTextField> formOptions) {
 		ArrayList<String> f_command = new ArrayList<String>();
 		f_command.add(manticoreExePath);
 		String[] argv = parseCommand(formOptions.get("argv").getText());
-		for(Entry<String, JTextField> option:formOptions.entrySet()) {
-			if(option.getKey()=="argv")continue;
-			for(String arg:parseCommand(option.getValue().getText())) {
+		for (Entry<String, JTextField> option : formOptions.entrySet()) {
+			if (option.getKey() == "argv")
+				continue;
+			for (String arg : parseCommand(option.getValue().getText())) {
 				f_command.add("--".concat(option.getKey()));
 				f_command.add(arg);
-			}	
+			}
 		}
-		
+
 		f_command.add(programPath);
 		f_command.addAll(Arrays.asList(argv));
-		Msg.info(this,f_command.get(0));
+		Msg.info(this, f_command.get(0));
 		return f_command.toArray(String[]::new);
 	}
-	
+
 	public String[] parseCommand(String string) {
 		final List<Character> WORD_DELIMITERS = Arrays.asList(' ', '\t');
 		final List<Character> QUOTE_CHARACTERS = Arrays.asList('"', '\'');

--- a/MUI/src/main/java/mui/MUILogProvider.java
+++ b/MUI/src/main/java/mui/MUILogProvider.java
@@ -3,6 +3,8 @@ package mui;
 import docking.*;
 import ghidra.framework.plugintool.ComponentProviderAdapter;
 import ghidra.framework.plugintool.PluginTool;
+import ghidra.util.Msg;
+
 import java.awt.*;
 import java.awt.event.*;
 import java.time.Instant;
@@ -10,6 +12,9 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.List;
+import java.util.Map.Entry;
+
 import javax.swing.*;
 
 public class MUILogProvider extends ComponentProviderAdapter {
@@ -34,9 +39,10 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		logPanel.add(logTabPane);
 	}
 
-	public void runMUI(String manticoreExePath, HashMap<String, Object> formOptions) {
+	public void runMUI(String manticoreExePath, String programPath, HashMap<String, JTextField> formOptions) {
 		MUILogContentComponent newTabContent = new MUILogContentComponent();
-		newTabContent.MUIInstance.callProc(manticoreExePath, formOptions);
+	
+		newTabContent.MUIInstance.callProc(buildCommand(manticoreExePath, programPath, formOptions));
 		logTabPane.add(
 			ZonedDateTime.now(ZoneId.systemDefault())
 					.format(DateTimeFormatter.ofPattern("HH:mm:ss")),
@@ -44,6 +50,61 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		logTabPane.setTabComponentAt(
 			logTabPane.getTabCount() - 1, new MUILogTabComponent(logTabPane, this));
 		logTabPane.setSelectedIndex(logTabPane.getTabCount() - 1);
+	}
+	
+	public String[] buildCommand(String manticoreExePath, String programPath, HashMap<String, JTextField> formOptions) {
+		ArrayList<String> f_command = new ArrayList<String>();
+		f_command.add(manticoreExePath);
+		String[] argv = parseCommand(formOptions.get("argv").getText());
+		for(Entry<String, JTextField> option:formOptions.entrySet()) {
+			if(option.getKey()=="argv")continue;
+			for(String arg:parseCommand(option.getValue().getText())) {
+				f_command.add("--".concat(option.getKey()));
+				f_command.add(arg);
+			}	
+		}
+		
+		f_command.add(programPath);
+		f_command.addAll(Arrays.asList(argv));
+		Msg.info(this,f_command.get(0));
+		return f_command.toArray(String[]::new);
+	}
+	
+	public String[] parseCommand(String string) {
+		final List<Character> WORD_DELIMITERS = Arrays.asList(' ', '\t');
+		final List<Character> QUOTE_CHARACTERS = Arrays.asList('"', '\'');
+		final char ESCAPE_CHARACTER = '\\';
+
+		StringBuilder wordBuilder = new StringBuilder();
+		List<String> words = new ArrayList<>();
+		char quote = 0;
+
+		for (int i = 0; i < string.length(); i++) {
+			char c = string.charAt(i);
+
+			if (c == ESCAPE_CHARACTER && i + 1 < string.length()) {
+				wordBuilder.append(string.charAt(++i));
+			}
+			else if (WORD_DELIMITERS.contains(c) && quote == 0) {
+				words.add(wordBuilder.toString());
+				wordBuilder.setLength(0);
+			}
+			else if (quote == 0 && QUOTE_CHARACTERS.contains(c)) {
+				quote = c;
+			}
+			else if (quote == c) {
+				quote = 0;
+			}
+			else {
+				wordBuilder.append(c);
+			}
+		}
+
+		if (wordBuilder.length() > 0) {
+			words.add(wordBuilder.toString());
+		}
+
+		return words.toArray(new String[0]);
 	}
 
 	public void noManticoreBinary() {

--- a/MUI/src/main/java/mui/MUIRunner.java
+++ b/MUI/src/main/java/mui/MUIRunner.java
@@ -27,7 +27,6 @@ public class MUIRunner {
 		isTerminated = true;
 	}
 
-	
 	public void callProc(String[] command) {
 
 		stopButton.setEnabled(true);

--- a/MUI/src/main/java/mui/MUIRunner.java
+++ b/MUI/src/main/java/mui/MUIRunner.java
@@ -49,74 +49,74 @@ public class MUIRunner {
 		
 	}
 	
-	public void callProc(String manticoreExePath, HashMap<String, Object> manticoreOptions) {
+	public void callProc(String[] command) {
 
-//		stopButton.setEnabled(true);
-//		logArea.append(
-//			"Command: " + String.join(" ", manticoreArgs) + System.lineSeparator() +
-//				System.lineSeparator());
-//
-//		SwingWorker sw =
-//			new SwingWorker() {
-//				Boolean errored = false;
-//
-//				@Override
-//				protected Object doInBackground() throws Exception {
-//					ProcessBuilder pb = new ProcessBuilder(manticoreArgs);
-//					try {
-//						Process p = pb.start();
-//						BufferedReader reader =
-//							new BufferedReader(new InputStreamReader(p.getInputStream()));
-//						String line = "";
-//						while ((line = reader.readLine()) != null && !isTerminated) {
-//							logArea.append(line);
-//							logArea.append(System.lineSeparator());
-//						}
-//						if (isTerminated) {
-//							p.destroy();
-//						}
-//						else {
-//							p.waitFor();
-//							final int exitValue = p.waitFor();
-//							if (exitValue != 0) {
-//								errored = true;
-//								try (final BufferedReader b =
-//									new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
-//									String eline;
-//									if ((eline = b.readLine()) != null) {
-//										logArea.append(eline);
-//									}
-//								}
-//								catch (final IOException e) {
-//									e.printStackTrace();
-//								}
-//							}
-//						}
-//						reader.close();
-//
-//					}
-//					catch (Exception e1) {
-//						errored = true;
-//						logArea.append(e1.getMessage());
-//						e1.printStackTrace();
-//					}
-//					return null;
-//				}
-//
-//				@Override
-//				protected void done() {
-//					if (isTerminated) {
-//						logArea.append("Manticore stopped by user.");
-//					}
-//					else if (errored) {
-//						logArea.append("Error! See stack trace above.");
-//					}
-//					else {
-//						logArea.append("Manticore execution complete.");
-//					}
-//					stopButton.setEnabled(false);
-//				}
-//			};
-//		sw.execute();
+		stopButton.setEnabled(true);
+		logArea.append(
+			"Command: " + String.join(" ", command) + System.lineSeparator() +
+				System.lineSeparator());
+
+		SwingWorker sw =
+			new SwingWorker() {
+				Boolean errored = false;
+
+				@Override
+				protected Object doInBackground() throws Exception {
+					ProcessBuilder pb = new ProcessBuilder(command);
+					try {
+						Process p = pb.start();
+						BufferedReader reader =
+							new BufferedReader(new InputStreamReader(p.getInputStream()));
+						String line = "";
+						while ((line = reader.readLine()) != null && !isTerminated) {
+							logArea.append(line);
+							logArea.append(System.lineSeparator());
+						}
+						if (isTerminated) {
+							p.destroy();
+						}
+						else {
+							p.waitFor();
+							final int exitValue = p.waitFor();
+							if (exitValue != 0) {
+								errored = true;
+								try (final BufferedReader b =
+									new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
+									String eline;
+									if ((eline = b.readLine()) != null) {
+										logArea.append(eline);
+									}
+								}
+								catch (final IOException e) {
+									e.printStackTrace();
+								}
+							}
+						}
+						reader.close();
+
+					}
+					catch (Exception e1) {
+						errored = true;
+						logArea.append(e1.getMessage());
+						e1.printStackTrace();
+					}
+					return null;
+				}
+
+				@Override
+				protected void done() {
+					if (isTerminated) {
+						logArea.append("Manticore stopped by user.");
+					}
+					else if (errored) {
+						logArea.append("Error! See stack trace above.");
+					}
+					else {
+						logArea.append("Manticore execution complete.");
+					}
+					stopButton.setEnabled(false);
+				}
+			};
+		sw.execute();
 	}
 }

--- a/MUI/src/main/java/mui/MUIRunner.java
+++ b/MUI/src/main/java/mui/MUIRunner.java
@@ -26,29 +26,29 @@ public class MUIRunner {
 	public void stopProc() {
 		isTerminated = true;
 	}
-	
-	
-	public void constructCommand(String manticoreExePath, HashMap<String, Object> manticoreOptions) {
+
+	public void constructCommand(String manticoreExePath,
+			HashMap<String, Object> manticoreOptions) {
 		StringBuilder cmd = new StringBuilder();
 		cmd.append(manticoreExePath);
 		cmd.append(" ");
-		
-		for (Entry<String, Object> option: manticoreOptions.entrySet()) {
+
+		for (Entry<String, Object> option : manticoreOptions.entrySet()) {
 			String name = option.getKey();
-			
-			String optType = (String) MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").get(name)[0].get("type");
-			
-			if (optType == "string" || optType=="number") {
-				
-			} else if (optType == "array") {
+
+			String optType =
+				(String) MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").get(name)[0].get("type");
+
+			if (optType == "string" || optType == "number") {
+
+			}
+			else if (optType == "array") {
 				//TODO: implement
 			}
 		}
 
-		
-		
 	}
-	
+
 	public void callProc(String[] command) {
 
 		stopButton.setEnabled(true);

--- a/MUI/src/main/java/mui/MUIRunner.java
+++ b/MUI/src/main/java/mui/MUIRunner.java
@@ -3,6 +3,10 @@ package mui;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import javax.swing.JButton;
 import javax.swing.JTextArea;
 import javax.swing.SwingWorker;
@@ -22,75 +26,97 @@ public class MUIRunner {
 	public void stopProc() {
 		isTerminated = true;
 	}
+	
+	
+	public void constructCommand(String manticoreExePath, HashMap<String, Object> manticoreOptions) {
+		StringBuilder cmd = new StringBuilder();
+		cmd.append(manticoreExePath);
+		cmd.append(" ");
+		
+		for (Entry<String, Object> option: manticoreOptions.entrySet()) {
+			String name = option.getKey();
+			
+			String optType = (String) MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").get(name)[0].get("type");
+			
+			if (optType == "string" || optType=="number") {
+				
+			} else if (optType == "array") {
+				//TODO: implement
+			}
+		}
 
-	public void callProc(String[] manticoreArgs) {
+		
+		
+	}
+	
+	public void callProc(String manticoreExePath, HashMap<String, Object> manticoreOptions) {
 
-		stopButton.setEnabled(true);
-		logArea.append(
-			"Command: " + String.join(" ", manticoreArgs) + System.lineSeparator() +
-				System.lineSeparator());
-
-		SwingWorker sw =
-			new SwingWorker() {
-				Boolean errored = false;
-
-				@Override
-				protected Object doInBackground() throws Exception {
-					ProcessBuilder pb = new ProcessBuilder(manticoreArgs);
-					try {
-						Process p = pb.start();
-						BufferedReader reader =
-							new BufferedReader(new InputStreamReader(p.getInputStream()));
-						String line = "";
-						while ((line = reader.readLine()) != null && !isTerminated) {
-							logArea.append(line);
-							logArea.append(System.lineSeparator());
-						}
-						if (isTerminated) {
-							p.destroy();
-						}
-						else {
-							p.waitFor();
-							final int exitValue = p.waitFor();
-							if (exitValue != 0) {
-								errored = true;
-								try (final BufferedReader b =
-									new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
-									String eline;
-									if ((eline = b.readLine()) != null) {
-										logArea.append(eline);
-									}
-								}
-								catch (final IOException e) {
-									e.printStackTrace();
-								}
-							}
-						}
-						reader.close();
-
-					}
-					catch (Exception e1) {
-						errored = true;
-						logArea.append(e1.getMessage());
-						e1.printStackTrace();
-					}
-					return null;
-				}
-
-				@Override
-				protected void done() {
-					if (isTerminated) {
-						logArea.append("Manticore stopped by user.");
-					}
-					else if (errored) {
-						logArea.append("Error! See stack trace above.");
-					}
-					else {
-						logArea.append("Manticore execution complete.");
-					}
-					stopButton.setEnabled(false);
-				}
-			};
-		sw.execute();
+//		stopButton.setEnabled(true);
+//		logArea.append(
+//			"Command: " + String.join(" ", manticoreArgs) + System.lineSeparator() +
+//				System.lineSeparator());
+//
+//		SwingWorker sw =
+//			new SwingWorker() {
+//				Boolean errored = false;
+//
+//				@Override
+//				protected Object doInBackground() throws Exception {
+//					ProcessBuilder pb = new ProcessBuilder(manticoreArgs);
+//					try {
+//						Process p = pb.start();
+//						BufferedReader reader =
+//							new BufferedReader(new InputStreamReader(p.getInputStream()));
+//						String line = "";
+//						while ((line = reader.readLine()) != null && !isTerminated) {
+//							logArea.append(line);
+//							logArea.append(System.lineSeparator());
+//						}
+//						if (isTerminated) {
+//							p.destroy();
+//						}
+//						else {
+//							p.waitFor();
+//							final int exitValue = p.waitFor();
+//							if (exitValue != 0) {
+//								errored = true;
+//								try (final BufferedReader b =
+//									new BufferedReader(new InputStreamReader(p.getErrorStream()))) {
+//									String eline;
+//									if ((eline = b.readLine()) != null) {
+//										logArea.append(eline);
+//									}
+//								}
+//								catch (final IOException e) {
+//									e.printStackTrace();
+//								}
+//							}
+//						}
+//						reader.close();
+//
+//					}
+//					catch (Exception e1) {
+//						errored = true;
+//						logArea.append(e1.getMessage());
+//						e1.printStackTrace();
+//					}
+//					return null;
+//				}
+//
+//				@Override
+//				protected void done() {
+//					if (isTerminated) {
+//						logArea.append("Manticore stopped by user.");
+//					}
+//					else if (errored) {
+//						logArea.append("Error! See stack trace above.");
+//					}
+//					else {
+//						logArea.append("Manticore execution complete.");
+//					}
+//					stopButton.setEnabled(false);
+//				}
+//			};
+//		sw.execute();
 	}
 }

--- a/MUI/src/main/java/mui/MUIRunner.java
+++ b/MUI/src/main/java/mui/MUIRunner.java
@@ -27,28 +27,7 @@ public class MUIRunner {
 		isTerminated = true;
 	}
 
-	public void constructCommand(String manticoreExePath,
-			HashMap<String, Object> manticoreOptions) {
-		StringBuilder cmd = new StringBuilder();
-		cmd.append(manticoreExePath);
-		cmd.append(" ");
-
-		for (Entry<String, Object> option : manticoreOptions.entrySet()) {
-			String name = option.getKey();
-
-			String optType =
-				(String) MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").get(name)[0].get("type");
-
-			if (optType == "string" || optType == "number") {
-
-			}
-			else if (optType == "array") {
-				//TODO: implement
-			}
-		}
-
-	}
-
+	
 	public void callProc(String[] command) {
 
 		stopButton.setEnabled(true);

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -16,7 +16,7 @@ public class MUISettings {
 						"type", "string",
 						"default", ""),
 					Map.of()},			
-				"stdinSize", new Map[] {
+				"native.stdin_size", new Map[] {
 					Map.of(
 						"title", "Stdin Size",
 						"description", "Stdin size to use for manticore",
@@ -31,7 +31,7 @@ public class MUISettings {
 						"elementType", "string",
 						"default", ""),
 					Map.of()},
-				"workspaceURL", new Map[] {
+				"workspace", new Map[] {
 					Map.of(
 						"title", "Workspace URL",
 						"description", "Workspace URL to use for manticore",
@@ -47,7 +47,7 @@ public class MUISettings {
 						"elementType", "string",
 						"default", ""),
 					Map.of()},
-				"symbolicFiles", new Map[] {
+				"file", new Map[] {
 					Map.of(
 						"title", "Symbolic Input Files",
 						"description", "Symbolic input files for manticore",

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -1,0 +1,59 @@
+package mui;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+public class MUISettings {
+
+	private static Map<String, Map<String, Map<Map<String, Object>, Map<String, Object>>>> SETTINGS =
+		Map.of(
+			"NATIVE_RUN_SETTINGS",
+			Map.of(
+				"concreteStart", Map.of(
+					Map.of(
+						"title", "Concrete Start",
+						"description", "Initial concrete data for the input symbolic buffer",
+						"type", "string",
+						"default", ""),
+					Map.of()),
+				"stdinSize", Map.of(
+					Map.of(
+						"title", "Stdin Size",
+						"description", "Stdin size to use for manticore",
+						"type", "number",
+						"default", 256),
+					Map.of()),
+				"argv", Map.of(
+					Map.of(
+						"title", "Program arguments (use + as a wildcard)",
+						"description", "Argv to use for manticore",
+						"type", "array",
+						"elementType", "string",
+						"default", new ArrayList<String>()),
+					Map.of()),
+				"workspaceURL", Map.of(
+					Map.of(
+						"title", "Workspace URL",
+						"description", "Workspace URL to use for manticore",
+						"type", "string",
+						"default", "mem:"),
+					Map.of(
+						"is_dir_path", true)),
+				"env", Map.of(
+					Map.of(
+						"title", "Environment Variables",
+						"description", "Environment variables for manticore",
+						"type", "array",
+						"elementType", "string",
+						"default", new ArrayList<String>()),
+					Map.of()),
+				"symbolicFiles", Map.of(
+					Map.of(
+						"title", "Symbolic Input Files",
+						"description", "Symbolic input files for manticore",
+						"type", "array",
+						"elementType", "string",
+						"default", new ArrayList<String>()),
+					Map.of())));
+
+}

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -5,55 +5,56 @@ import java.util.Map;
 
 public class MUISettings {
 
-	private static Map<String, Map<String, Map<Map<String, Object>, Map<String, Object>>>> SETTINGS =
+	public static Map<String, Map<String, Map<String, Object>[]>> SETTINGS =
 		Map.of(
 			"NATIVE_RUN_SETTINGS",
 			Map.of(
-				"concreteStart", Map.of(
+				"concreteStart", new Map[] {
 					Map.of(
 						"title", "Concrete Start",
 						"description", "Initial concrete data for the input symbolic buffer",
 						"type", "string",
 						"default", ""),
-					Map.of()),
-				"stdinSize", Map.of(
+					Map.of()},			
+				"stdinSize", new Map[] {
 					Map.of(
 						"title", "Stdin Size",
 						"description", "Stdin size to use for manticore",
 						"type", "number",
 						"default", 256),
-					Map.of()),
-				"argv", Map.of(
+					Map.of()},
+				"argv", new Map[] {
 					Map.of(
 						"title", "Program arguments (use + as a wildcard)",
 						"description", "Argv to use for manticore",
 						"type", "array",
 						"elementType", "string",
 						"default", new ArrayList<String>()),
-					Map.of()),
-				"workspaceURL", Map.of(
+					Map.of()},
+				"workspaceURL", new Map[] {
 					Map.of(
 						"title", "Workspace URL",
 						"description", "Workspace URL to use for manticore",
 						"type", "string",
 						"default", "mem:"),
 					Map.of(
-						"is_dir_path", true)),
-				"env", Map.of(
+						"is_dir_path", true)},
+				"env", new Map[] {
 					Map.of(
 						"title", "Environment Variables",
 						"description", "Environment variables for manticore",
 						"type", "array",
 						"elementType", "string",
 						"default", new ArrayList<String>()),
-					Map.of()),
-				"symbolicFiles", Map.of(
+					Map.of()},
+				"symbolicFiles", new Map[] {
 					Map.of(
 						"title", "Symbolic Input Files",
 						"description", "Symbolic input files for manticore",
 						"type", "array",
 						"elementType", "string",
 						"default", new ArrayList<String>()),
-					Map.of())));
+					Map.of()})
+			);
 
 }

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -29,7 +29,7 @@ public class MUISettings {
 						"description", "Argv to use for manticore",
 						"type", "array",
 						"elementType", "string",
-						"default", new ArrayList<String>()),
+						"default", ""),
 					Map.of()},
 				"workspaceURL", new Map[] {
 					Map.of(
@@ -45,7 +45,7 @@ public class MUISettings {
 						"description", "Environment variables for manticore",
 						"type", "array",
 						"elementType", "string",
-						"default", new ArrayList<String>()),
+						"default", ""),
 					Map.of()},
 				"symbolicFiles", new Map[] {
 					Map.of(
@@ -53,7 +53,7 @@ public class MUISettings {
 						"description", "Symbolic input files for manticore",
 						"type", "array",
 						"elementType", "string",
-						"default", new ArrayList<String>()),
+						"default", ""),
 					Map.of()})
 			);
 

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -15,14 +15,14 @@ public class MUISettings {
 						"description", "Initial concrete data for the input symbolic buffer",
 						"type", "string",
 						"default", ""),
-					Map.of()},			
+					Map.of() },
 				"native.stdin_size", new Map[] {
 					Map.of(
 						"title", "Stdin Size",
 						"description", "Stdin size to use for manticore",
 						"type", "number",
 						"default", 256),
-					Map.of()},
+					Map.of() },
 				"argv", new Map[] {
 					Map.of(
 						"title", "Program arguments (use + as a wildcard)",
@@ -30,7 +30,7 @@ public class MUISettings {
 						"type", "array",
 						"elementType", "string",
 						"default", ""),
-					Map.of()},
+					Map.of() },
 				"workspace", new Map[] {
 					Map.of(
 						"title", "Workspace URL",
@@ -38,7 +38,7 @@ public class MUISettings {
 						"type", "string",
 						"default", "mem:"),
 					Map.of(
-						"is_dir_path", true)},
+						"is_dir_path", true) },
 				"env", new Map[] {
 					Map.of(
 						"title", "Environment Variables",
@@ -46,7 +46,7 @@ public class MUISettings {
 						"type", "array",
 						"elementType", "string",
 						"default", ""),
-					Map.of()},
+					Map.of() },
 				"file", new Map[] {
 					Map.of(
 						"title", "Symbolic Input Files",
@@ -54,7 +54,6 @@ public class MUISettings {
 						"type", "array",
 						"elementType", "string",
 						"default", ""),
-					Map.of()})
-			);
+					Map.of() }));
 
 }

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -9,7 +9,7 @@ public class MUISettings {
 		Map.of(
 			"NATIVE_RUN_SETTINGS",
 			Map.of(
-				"concreteStart", new Map[] {
+				"data", new Map[] {
 					Map.of(
 						"title", "Concrete Start",
 						"description", "Initial concrete data for the input symbolic buffer",

--- a/MUI/src/main/java/mui/MUISetupProvider.java
+++ b/MUI/src/main/java/mui/MUISetupProvider.java
@@ -7,10 +7,15 @@ import ghidra.framework.ApplicationConfiguration;
 import ghidra.framework.plugintool.ComponentProviderAdapter;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.listing.Program;
+import ghidra.util.Msg;
+
 import java.awt.*;
 import java.awt.event.*;
+import java.io.IOException;
 import java.util.*;
 import java.util.List;
+import java.util.Map.Entry;
+
 import javax.swing.*;
 
 public class MUISetupProvider extends ComponentProviderAdapter {
@@ -30,9 +35,14 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 
 	private MUILogProvider logProvider;
 
+	private JPanel formPanel;
+	private HashMap<String, Object> formOptions;
+//	private HashMap<String, JPanel> inputRows;
+	
 	public MUISetupProvider(PluginTool tool, String name, MUILogProvider log) {
 		super(tool, name, name);
 		setLogProvider(log);
+		buildFormPanel();
 		buildMainPanel();
 		setTitle("MUI Setup");
 		setDefaultWindowPosition(WindowPosition.WINDOW);
@@ -43,65 +53,123 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		logProvider = log;
 	}
 
-	private void buildMainPanel() {
-		mainPanel = new JPanel(new GridBagLayout());
-		mainPanel.setMinimumSize(new Dimension(500, 500));
+	private void buildFormPanel() throws UnsupportedOperationException {
+		formPanel = new JPanel();
+		formPanel.setLayout(new BoxLayout(formPanel, BoxLayout.Y_AXIS));
+		formPanel.setMinimumSize(new Dimension(800,500));
+		formOptions = new HashMap<>();
+		
+		for (Entry<String, Map<String, Object>[]> option:MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").entrySet()) {
+			String name = option.getKey();
+			Map<String, Object> prop = option.getValue()[0];
+			Map<String, Object> extra = option.getValue()[1];
+			
+			String title = (String) prop.get("title");
+			
+			JPanel inputRow = new JPanel(new GridBagLayout());
+		//	inputRows.put(name, inputRow);
+			inputRow.setMinimumSize(new Dimension(800,100));
+			GridBagConstraints inputRowConstraints = new GridBagConstraints();
+			inputRowConstraints.fill = GridBagConstraints.HORIZONTAL;
+			
+			inputRowConstraints.gridx=0;
+			inputRowConstraints.gridwidth=3;
+			inputRowConstraints.gridy=0;
+			inputRowConstraints.gridheight=1;
+			inputRowConstraints.weightx = 1.0;
+			inputRowConstraints.weighty = 1.0;
+			inputRow.add(new JLabel(title), inputRowConstraints);
+			
+			JTextField entry = new JTextField();
+			
+			if(extra.containsKey("is_dir_path") && (Boolean) extra.get("is_dir_path")) {
+				entry.setText((String) prop.get("default"));
+				inputRowConstraints.gridx=3;
+				inputRowConstraints.gridwidth=3;
+				inputRow.add(entry, inputRowConstraints);
+				
+				JFileChooser chooser = new JFileChooser();
+				chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+				chooser.setDialogTitle("Set Workspace Folder");
+				
+				JButton selectButton = new JButton("Select...");
+				selectButton.addActionListener(new ActionListener() {
 
-		mainPanelConstraints = new GridBagConstraints();
-		mainPanelConstraints.fill = GridBagConstraints.BOTH;
-		mainPanelConstraints.gridwidth = GridBagConstraints.REMAINDER;
-		mainPanelConstraints.weightx = 0.9;
-		mainPanelConstraints.weighty = 0.9;
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						int returnVal = chooser.showOpenDialog(null);
+						if(returnVal==JFileChooser.APPROVE_OPTION) {
+							try {
+								String path = chooser.getSelectedFile().getCanonicalPath();
+								entry.setText(path);
+							} catch (IOException e1) {
+								e1.printStackTrace();
+							}
+						}
+					}
+					
+				});
+				
+				inputRowConstraints.gridx=6;
+				inputRowConstraints.gridwidth=1;
+				inputRow.add(selectButton, inputRowConstraints);
+				
+				formOptions.put(name, entry);
+			} else if (prop.get("type") == "string" || prop.get("type") == "number") {
+				entry.setText(prop.get("default").toString());
+				inputRowConstraints.gridx=3;
+				inputRowConstraints.gridwidth=4;
+				inputRow.add(entry, inputRowConstraints);
+				
+				formOptions.put(name, entry);
+			} else if (prop.get("type") == "array") {
+				// TODO: doesn't handle default param for arrays, but not needed as part of sensible defaults for running manticore on native binaries
+				ArrayList<JTextField> arr_tfs = new ArrayList<JTextField>();
+				
+				JButton add_tf = new JButton("+");
+				add_tf.addActionListener(new ActionListener() {
 
-		inputPanel = new JPanel(new GridBagLayout());
-
-		inputPanelConstraints = new GridBagConstraints();
-		inputPanelConstraints.fill = GridBagConstraints.BOTH;
-
-		inputPanelConstraints.gridx = 0;
-		inputPanelConstraints.gridy = 0;
-		inputPanelConstraints.weightx = 0.25;
-		inputPanelConstraints.gridwidth = 1;
-		inputPanel.add(new JLabel("Program Path:"), inputPanelConstraints);
-
-		if (programPath == null) {
-			programPath = "";
-		}
-		programPathLbl = new JLabel(programPath);
-		inputPanelConstraints.gridx = 1;
-		inputPanelConstraints.gridy = 0;
-		inputPanelConstraints.weightx = 0.75;
-		inputPanelConstraints.gridwidth = 3;
-		inputPanel.add(programPathLbl, inputPanelConstraints);
-
-		JLabel manticoreArgsLbl = new JLabel("Manticore Args:");
-		inputPanelConstraints.gridx = 0;
-		inputPanelConstraints.gridy = 1;
-		inputPanelConstraints.weightx = 0.0;
-		inputPanelConstraints.gridwidth = 4;
-		inputPanel.add(manticoreArgsLbl, inputPanelConstraints);
-
-		manticoreArgsArea = new JTextArea();
-		manticoreArgsArea.setToolTipText("Enter arguments as you would in CLI");
-		manticoreArgsArea.setLineWrap(true);
-		manticoreArgsArea.setWrapStyleWord(true);
-		inputPanelConstraints.gridx = 0;
-		inputPanelConstraints.gridy = 2;
-		inputPanelConstraints.ipady = 50;
-		inputPanelConstraints.weightx = 0.0;
-		inputPanelConstraints.gridwidth = 4;
-		inputPanel.add(manticoreArgsArea, inputPanelConstraints);
-
-		try {
-			if (!Application.isInitialized()) {
-				Application.initializeApplication(
-					new GhidraApplicationLayout(), new ApplicationConfiguration());
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						Msg.info(this,String.format("clicked + and and constraintgridy is %s and inputRow is ",inputRowConstraints.gridy)+inputRow.toString());
+						inputRowConstraints.gridy++;
+						arr_tfs.add(new JTextField());
+						inputRow.add(arr_tfs.get(arr_tfs.size()-1), inputRowConstraints);
+					}
+					
+				});
+				inputRowConstraints.gridx=3;
+				inputRowConstraints.gridwidth=4;
+				inputRow.add(add_tf,inputRowConstraints);
+				
+				for(Object element: (ArrayList) prop.get("default")) {
+					inputRowConstraints.gridy++;
+					arr_tfs.add(new JTextField(element.toString()));
+					inputRow.add(arr_tfs.get(arr_tfs.size()-1), inputRowConstraints);
+				}
+				
+				formOptions.put(name, arr_tfs);
+				
+				
+			} else {
+				// TODO: to achieve parity with Binja MUI, type==boolean must be supported, but not needed as part of sensible defaults for running manticore on native binaries
+				throw new UnsupportedOperationException(String.format("[ERROR] Cannot create input row for %s with the type %s", name, prop.get("type")));
 			}
-			manticoreExePath = Application.getOSFile("manticore").getAbsolutePath().concat(" ");
+			
+			Msg.info(this, formOptions.toString());
+			formPanel.add(inputRow);
+			
 		}
-		catch (Exception e) {
-			manticoreExePath = "";
-		}
+	}
+	
+	private void buildMainPanel() {
+		mainPanel = new JPanel(new BorderLayout());
+		mainPanel.setMinimumSize(new Dimension(900, 500));
+
+		
+		mainPanel.add(formPanel, BorderLayout.CENTER);
+		
+		
 		runBtn = new JButton("Run");
 		runBtn.addActionListener(
 			new ActionListener() {
@@ -117,25 +185,77 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 					}
 				}
 			});
-		inputPanelConstraints.gridx = 0;
-		inputPanelConstraints.gridy = 3;
-		inputPanelConstraints.weightx = 0.9;
-		inputPanelConstraints.anchor = GridBagConstraints.SOUTH;
-		inputPanelConstraints.ipady = 0;
-		inputPanelConstraints.gridwidth = 4;
-		inputPanelConstraints.insets = new Insets(10, 0, 0, 0);
-		inputPanel.add(runBtn, inputPanelConstraints);
 
-		mainPanel.add(inputPanel, mainPanelConstraints);
+		
+
+//		inputPanel = new JPanel(new GridBagLayout());
+//
+//		inputPanelConstraints = new GridBagConstraints();
+//		inputPanelConstraints.fill = GridBagConstraints.BOTH;
+//
+//		inputPanelConstraints.gridx = 0;
+//		inputPanelConstraints.gridy = 0;
+//		inputPanelConstraints.weightx = 0.25;
+//		inputPanelConstraints.gridwidth = 1;
+//		inputPanel.add(new JLabel("Program Path:"), inputPanelConstraints);
+//
+//		if (programPath == null) {
+//			programPath = "";
+//		}
+//		programPathLbl = new JLabel(programPath);
+//		inputPanelConstraints.gridx = 1;
+//		inputPanelConstraints.gridy = 0;
+//		inputPanelConstraints.weightx = 0.75;
+//		inputPanelConstraints.gridwidth = 3;
+//		inputPanel.add(programPathLbl, inputPanelConstraints);
+//
+//		JLabel manticoreArgsLbl = new JLabel("Manticore Args:");
+//		inputPanelConstraints.gridx = 0;
+//		inputPanelConstraints.gridy = 1;
+//		inputPanelConstraints.weightx = 0.0;
+//		inputPanelConstraints.gridwidth = 4;
+//		inputPanel.add(manticoreArgsLbl, inputPanelConstraints);
+//
+//		manticoreArgsArea = new JTextArea();
+//		manticoreArgsArea.setToolTipText("Enter arguments as you would in CLI");
+//		manticoreArgsArea.setLineWrap(true);
+//		manticoreArgsArea.setWrapStyleWord(true);
+//		inputPanelConstraints.gridx = 0;
+//		inputPanelConstraints.gridy = 2;
+//		inputPanelConstraints.ipady = 50;
+//		inputPanelConstraints.weightx = 0.0;
+//		inputPanelConstraints.gridwidth = 4;
+//		inputPanel.add(manticoreArgsArea, inputPanelConstraints);
+//		
+//		try {
+//			if (!Application.isInitialized()) {
+//				Application.initializeApplication(
+//					new GhidraApplicationLayout(), new ApplicationConfiguration());
+//			}
+//			manticoreExePath = Application.getOSFile("manticore").getAbsolutePath().concat(" ");
+//		}
+//		catch (Exception e) {
+//			manticoreExePath = "";
+//		}
+//		inputPanelConstraints.gridx = 0;
+//		inputPanelConstraints.gridy = 3;
+//		inputPanelConstraints.weightx = 0.9;
+//		inputPanelConstraints.anchor = GridBagConstraints.SOUTH;
+//		inputPanelConstraints.ipady = 0;
+//		inputPanelConstraints.gridwidth = 4;
+//		inputPanelConstraints.insets = new Insets(10, 0, 0, 0);
+//		inputPanel.add(runBtn, inputPanelConstraints);
+//
+//		mainPanel.add(inputPanel, mainPanelConstraints);
 	}
 
 	public void setProgram(Program p) {
 		program = p;
 		programPath = program.getExecutablePath();
-		if (programPathLbl != null) { // if mainPanel built before program activated
-			programPathLbl.setText(programPath);
-		}
-		manticoreArgsArea.setText("--workspace tmpMUI ".concat(programPath));
+//		if (programPathLbl != null) { // if mainPanel built before program activated
+//			programPathLbl.setText(programPath);
+//		}
+//		manticoreArgsArea.setText("--workspace tmpMUI ".concat(programPath));
 	}
 
 	/**

--- a/MUI/src/main/java/mui/MUISetupProvider.java
+++ b/MUI/src/main/java/mui/MUISetupProvider.java
@@ -36,9 +36,9 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 	private MUILogProvider logProvider;
 
 	private JPanel formPanel;
-	
+
 	private HashMap<String, JTextField> formOptions;
-	
+
 	public MUISetupProvider(PluginTool tool, String name, MUILogProvider log) {
 		super(tool, name, name);
 		setLogProvider(log);
@@ -55,94 +55,102 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 
 	private void buildFormPanel() throws UnsupportedOperationException {
 		formPanel = new JPanel();
-		formPanel.setLayout(new GridLayout(MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").size(),2));
-		formPanel.setMinimumSize(new Dimension(800,500));
-		
+		formPanel.setLayout(
+			new GridLayout(MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").size(), 2));
+		formPanel.setMinimumSize(new Dimension(800, 500));
+
 		formOptions = new HashMap<String, JTextField>();
-		
-		for (Entry<String, Map<String, Object>[]> option:MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").entrySet()) {
+
+		for (Entry<String, Map<String, Object>[]> option : MUISettings.SETTINGS
+				.get("NATIVE_RUN_SETTINGS")
+				.entrySet()) {
 			String name = option.getKey();
 
 			Map<String, Object> prop = option.getValue()[0];
 			Map<String, Object> extra = option.getValue()[1];
-			
+
 			String title = (String) prop.get("title");
 			formPanel.add(new JLabel(title));
-			
+
 			JTextField entry = new JTextField();
-			
-			if(extra.containsKey("is_dir_path") && (Boolean) extra.get("is_dir_path")) {
-				
+
+			if (extra.containsKey("is_dir_path") && (Boolean) extra.get("is_dir_path")) {
+
 				JPanel inputRow = new JPanel(new GridBagLayout());
-				inputRow.setMinimumSize(new Dimension(800,100));
+				inputRow.setMinimumSize(new Dimension(800, 100));
 				GridBagConstraints inputRowConstraints = new GridBagConstraints();
 				inputRowConstraints.fill = GridBagConstraints.HORIZONTAL;
-				
-				inputRowConstraints.gridx=0;
-				inputRowConstraints.gridwidth=3;
-				inputRowConstraints.gridy=0;
-				inputRowConstraints.gridheight=1;
+
+				inputRowConstraints.gridx = 0;
+				inputRowConstraints.gridwidth = 3;
+				inputRowConstraints.gridy = 0;
+				inputRowConstraints.gridheight = 1;
 				inputRowConstraints.weightx = 0.75;
-				
+
 				entry.setText((String) prop.get("default"));
 				inputRow.add(entry, inputRowConstraints);
-				
+
 				JFileChooser chooser = new JFileChooser();
 				chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 				chooser.setDialogTitle("Set Workspace Folder");
-				
+
 				JButton selectButton = new JButton("Select...");
 				selectButton.addActionListener(new ActionListener() {
 
 					@Override
 					public void actionPerformed(ActionEvent e) {
 						int returnVal = chooser.showOpenDialog(null);
-						if(returnVal==JFileChooser.APPROVE_OPTION) {
+						if (returnVal == JFileChooser.APPROVE_OPTION) {
 							try {
 								String path = chooser.getSelectedFile().getCanonicalPath();
 								entry.setText(path);
-							} catch (IOException e1) {
+							}
+							catch (IOException e1) {
 								e1.printStackTrace();
 							}
 						}
 					}
-					
+
 				});
-				
-				inputRowConstraints.gridx=3;
-				inputRowConstraints.gridwidth=1;
-				inputRowConstraints.weightx=0.25;
+
+				inputRowConstraints.gridx = 3;
+				inputRowConstraints.gridwidth = 1;
+				inputRowConstraints.weightx = 0.25;
 				inputRow.add(selectButton, inputRowConstraints);
-				
+
 				formPanel.add(inputRow);
-				
-			} else if (prop.get("type") == "string" || prop.get("type") == "number") {
+
+			}
+			else if (prop.get("type") == "string" || prop.get("type") == "number") {
 				entry.setText(prop.get("default").toString());
 				entry.setToolTipText("Only 1 value allowed");
-				formPanel.add(entry);				
-			} else if (prop.get("type") == "array") {
+				formPanel.add(entry);
+			}
+			else if (prop.get("type") == "array") {
 				// TODO: doesn't handle default param for arrays, but not needed as part of sensible defaults for running manticore on native binaries
 				// for now, same UI as string/num, and we will parse space-separated args
 				entry.setText(prop.get("default").toString());
 				entry.setToolTipText("You can space-separate multiple arguments");
-				formPanel.add(entry);					
-			} else {
-				// TODO: to achieve parity with Binja MUI, type==boolean must be supported, but not needed as part of sensible defaults for running manticore on native binaries
-				throw new UnsupportedOperationException(String.format("[ERROR] Cannot create input row for %s with the type %s", name, prop.get("type")));
+				formPanel.add(entry);
 			}
-			
+			else {
+				// TODO: to achieve parity with Binja MUI, type==boolean must be supported, but not needed as part of sensible defaults for running manticore on native binaries
+				throw new UnsupportedOperationException(
+					String.format("[ERROR] Cannot create input row for %s with the type %s", name,
+						prop.get("type")));
+			}
+
 			formOptions.put(name, entry);
-						
+
 		}
 	}
-	
+
 	private void buildMainPanel() {
 		mainPanel = new JPanel(new BorderLayout());
 		mainPanel.setMinimumSize(new Dimension(900, 500));
 
-		
 		mainPanel.add(formPanel, BorderLayout.CENTER);
-		
+
 		try {
 			if (!Application.isInitialized()) {
 				Application.initializeApplication(
@@ -168,8 +176,8 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 					}
 				}
 			});
-		
-		mainPanel.add(runBtn,BorderLayout.PAGE_END);
+
+		mainPanel.add(runBtn, BorderLayout.PAGE_END);
 	}
 
 	public void setProgram(Program p) {

--- a/MUI/src/main/java/mui/MUISetupProvider.java
+++ b/MUI/src/main/java/mui/MUISetupProvider.java
@@ -37,7 +37,7 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 
 	private JPanel formPanel;
 	
-	private HashMap<String, Object> formOptions;
+	private HashMap<String, JTextField> formOptions;
 	
 	public MUISetupProvider(PluginTool tool, String name, MUILogProvider log) {
 		super(tool, name, name);
@@ -58,7 +58,7 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		formPanel.setLayout(new GridLayout(MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").size(),2));
 		formPanel.setMinimumSize(new Dimension(800,500));
 		
-		formOptions = new HashMap<String, Object>();
+		formOptions = new HashMap<String, JTextField>();
 		
 		for (Entry<String, Map<String, Object>[]> option:MUISettings.SETTINGS.get("NATIVE_RUN_SETTINGS").entrySet()) {
 			String name = option.getKey();
@@ -163,9 +163,8 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 						logProvider.noManticoreBinary();
 					}
 					else {
-						formOptions.put("programPath",programPath);
 						logProvider.runMUI(
-							manticoreExePath, formOptions);
+							manticoreExePath, programPath, formOptions);
 					}
 				}
 			});
@@ -176,47 +175,6 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 	public void setProgram(Program p) {
 		program = p;
 		programPath = program.getExecutablePath();
-	}
-
-	/**
-	 * Tokenizes a string by spaces, but takes into account spaces embedded in quotes or escaped
-	 * spaces. Should no longer be required once UI for args is implemented.
-	 */
-	public String[] parseCommand(String string) {
-		final List<Character> WORD_DELIMITERS = Arrays.asList(' ', '\t');
-		final List<Character> QUOTE_CHARACTERS = Arrays.asList('"', '\'');
-		final char ESCAPE_CHARACTER = '\\';
-
-		StringBuilder wordBuilder = new StringBuilder();
-		List<String> words = new ArrayList<>();
-		char quote = 0;
-
-		for (int i = 0; i < string.length(); i++) {
-			char c = string.charAt(i);
-
-			if (c == ESCAPE_CHARACTER && i + 1 < string.length()) {
-				wordBuilder.append(string.charAt(++i));
-			}
-			else if (WORD_DELIMITERS.contains(c) && quote == 0) {
-				words.add(wordBuilder.toString());
-				wordBuilder.setLength(0);
-			}
-			else if (quote == 0 && QUOTE_CHARACTERS.contains(c)) {
-				quote = c;
-			}
-			else if (quote == c) {
-				quote = 0;
-			}
-			else {
-				wordBuilder.append(c);
-			}
-		}
-
-		if (wordBuilder.length() > 0) {
-			words.add(wordBuilder.toString());
-		}
-
-		return words.toArray(new String[0]);
 	}
 
 	@Override

--- a/MUI/src/main/java/mui/MUISetupProvider.java
+++ b/MUI/src/main/java/mui/MUISetupProvider.java
@@ -22,7 +22,6 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 
 	private JPanel mainPanel;
 	private String programPath;
-	private JButton runBtn;
 	private String manticoreExePath;
 
 	private MUILogProvider logProvider;
@@ -81,7 +80,7 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 			}
 		}
 	}
-	
+
 	private JTextField createStringNumberInput(String defaultStr) {
 		JTextField entry = new JTextField();
 		entry.setText(defaultStr);
@@ -89,7 +88,7 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		formPanel.add(entry);
 		return entry;
 	}
-	
+
 	private JTextField createArrayInput() {
 		// TODO: doesn't handle default param for arrays, but not needed as part of sensible defaults for running manticore on native binaries
 		// for now, same UI as string/num, and we will parse space-separated args
@@ -98,7 +97,7 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		formPanel.add(entry);
 		return entry;
 	}
-	
+
 	private JTextField createPathInput(String defaultStr) {
 		JTextField entry = new JTextField();
 
@@ -147,7 +146,6 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		formPanel.add(inputRow);
 		return entry;
 	}
-	
 
 	private void buildMainPanel() {
 		mainPanel = new JPanel(new BorderLayout());
@@ -165,7 +163,17 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		catch (Exception e) {
 			manticoreExePath = "";
 		}
-		runBtn = new JButton("Run");
+
+		JPanel bottomPanel = new JPanel(new BorderLayout());
+
+		bottomPanel.add(new JLabel("Extra Manticore Arguments:"), BorderLayout.NORTH);
+
+		JTextArea moreArgs = new JTextArea();
+		moreArgs.setLineWrap(true);
+		moreArgs.setWrapStyleWord(true);
+		bottomPanel.add(moreArgs, BorderLayout.CENTER);
+
+		JButton runBtn = new JButton("Run");
 		runBtn.addActionListener(
 			new ActionListener() {
 
@@ -176,12 +184,13 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 					}
 					else {
 						logProvider.runMUI(
-							manticoreExePath, programPath, formOptions);
+							manticoreExePath, programPath, formOptions, moreArgs.getText());
 					}
 				}
 			});
+		bottomPanel.add(runBtn, BorderLayout.SOUTH);
 
-		mainPanel.add(runBtn, BorderLayout.PAGE_END);
+		mainPanel.add(bottomPanel, BorderLayout.SOUTH);
 	}
 
 	public void setProgram(Program p) {


### PR DESCRIPTION
As per https://github.com/trailofbits/MUI/issues/29

Adds a small UI change that allows user to quickly alter important manticore options
![image](https://user-images.githubusercontent.com/29654756/148781624-395e3de1-8aae-48c7-8667-c4714afaee0d.png)

Options presented based on the run-dialog in binja plugin.
Validation is handled by manticore itself, where if an option is invalid the stack trace is printed to the MUI log.