### PR TITLE
Improve documentation, add JavaDoc comments

### DIFF
--- a/MUI/src/main/java/mui/MUILogContentComponent.java
+++ b/MUI/src/main/java/mui/MUILogContentComponent.java
@@ -10,7 +10,9 @@ import javax.swing.JTextArea;
 import javax.swing.JToolBar;
 import javax.swing.ScrollPaneConstants;
 import resources.ResourceManager;
-
+/**
+ * Provides the component for the Tab Content in the MUI Log tabbed pane.
+ */
 public class MUILogContentComponent extends JPanel {
 
 	public ManticoreRunner MUIInstance;
@@ -30,6 +32,9 @@ public class MUILogContentComponent extends JPanel {
 		buildToolBar();
 	}
 
+	/**
+	 * Builds a scrollable, uneditable TextArea which displays the logs of a Manticore instance.
+	 */
 	public void buildLogArea() {
 		logArea.setEditable(false);
 		logArea.setLineWrap(true);
@@ -43,6 +48,9 @@ public class MUILogContentComponent extends JPanel {
 		add(logScrollPane, BorderLayout.CENTER);
 	}
 
+	/**
+	 * Builds the log's toolbar including a Stop button that will terminate the Manticore instance of the currently-focused tab.
+	 */
 	public void buildToolBar() {
 		JToolBar logToolBar = new JToolBar();
 		logToolBar.setFloatable(false);

--- a/MUI/src/main/java/mui/MUILogContentComponent.java
+++ b/MUI/src/main/java/mui/MUILogContentComponent.java
@@ -10,6 +10,7 @@ import javax.swing.JTextArea;
 import javax.swing.JToolBar;
 import javax.swing.ScrollPaneConstants;
 import resources.ResourceManager;
+
 /**
  * Provides the component for the Tab Content in the MUI Log tabbed pane.
  */

--- a/MUI/src/main/java/mui/MUILogProvider.java
+++ b/MUI/src/main/java/mui/MUILogProvider.java
@@ -187,18 +187,6 @@ public class MUILogProvider extends ComponentProviderAdapter {
 	}
 
 	/**
-	 * @deprecated
-	 */
-	public void noManticoreBinary() {
-		MUILogContentComponent newTabContent = new MUILogContentComponent();
-		newTabContent.logArea.append("No manticore binary found!");
-		newTabContent.stopButton.setEnabled(false);
-		logTabPane.add(Long.toString(Instant.now().getEpochSecond()), newTabContent);
-		logTabPane.setTabComponentAt(
-			logTabPane.getTabCount() - 1, new MUILogTabComponent(logTabPane, this));
-	}
-
-	/**
 	 * Performs auxiliary actions when closing a tab, including stopping the Manticore instance and removing the tab component from the tab pane.
 	 * @param tabIndex The index of the closed tab in the MUI Log tab pane.
 	 */

--- a/MUI/src/main/java/mui/MUILogProvider.java
+++ b/MUI/src/main/java/mui/MUILogProvider.java
@@ -18,6 +18,9 @@ import java.util.Map.Entry;
 
 import javax.swing.*;
 
+/**
+ * Provides the "MUI Log" component used to display Manticore Logs. Also acts as the control center for the StateList component and for managing the different Manticore instances.
+ */
 public class MUILogProvider extends ComponentProviderAdapter {
 
 	private JPanel logPanel;
@@ -33,6 +36,9 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		setVisible(false);
 	}
 
+	/** 
+	 * Builds main component panel which hosts multiple log tabs.
+	 */
 	private void buildLogPanel() {
 		logPanel = new JPanel();
 		logPanel.setLayout(new BorderLayout());
@@ -42,6 +48,12 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		logPanel.add(logTabPane);
 	}
 
+	/**
+	 * Builds and makes changes to UI elements when a user attempts to run a new instance of Manticore, and calls the function that actually creates the new Manticore process.
+	 * @param programPath Path of the binary being analyzed.
+	 * @param formOptions Map storing pre-selected key Manticore options.
+	 * @param moreArgs Additional Manticore arguments set by the user.
+	 */
 	public void runMUI(String programPath,
 			HashMap<String, JTextField> formOptions, String moreArgs) {
 		MUILogContentComponent newTabContent = new MUILogContentComponent();
@@ -60,9 +72,15 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		newTabContent.requestFocusInWindow();
 
 	}
-
-	public String[] buildCommand(String programPath,
-			HashMap<String, JTextField> formOptions, String moreArgs) {
+	
+	/**
+	 * Structures Manticore argument data input by the user to be compatible with ProcessBuilder.
+	 * @param programPath Path of the binary being analyzed.
+	 * @param formOptions Map storing pre-selected key Manticore options.
+	 * @param moreArgs Additional Manticore arguments set by the user.
+	 * @return String array suitable to be passed to a ProcessBuilder.
+	 */
+	public String[] buildCommand(String programPath, HashMap<String, JTextField> formOptions, String moreArgs) {
 		ArrayList<String> f_command = new ArrayList<String>();
 		f_command.add(formOptions.get("{mcore_binary}").getText());
 
@@ -70,13 +88,13 @@ public class MUILogProvider extends ComponentProviderAdapter {
 			if (Arrays.asList("argv", "{mcore_binary}", "{state_server_port}")
 					.contains(option.getKey()))
 				continue;
-			for (String arg : parseCommand(option.getValue().getText())) {
+			for (String arg : tokenizeArrayInput(option.getValue().getText())) {
 				f_command.add("--".concat(option.getKey()));
 				f_command.add(arg);
 			}
 		}
 
-		f_command.addAll(Arrays.asList(parseCommand(moreArgs)));
+		f_command.addAll(Arrays.asList(tokenizeArrayInput(moreArgs)));
 
 		f_command.add("--core.PORT");
 
@@ -94,12 +112,17 @@ public class MUILogProvider extends ComponentProviderAdapter {
 
 		f_command.add(programPath);
 
-		String[] argv = parseCommand(formOptions.get("argv").getText());
+		String[] argv = tokenizeArrayInput(formOptions.get("argv").getText());
 		f_command.addAll(Arrays.asList(argv));
 		Msg.info(this, f_command.get(0));
 		return f_command.toArray(String[]::new);
 	}
 
+	/**
+	 * Checks whether a port is available or already in use.
+	 * @param port The port to check the availability of.
+	 * @return True if the given port is available, False if it's in use.
+	 */
 	private boolean portAvailable(int port) {
 		Socket s = null;
 		try {
@@ -121,7 +144,12 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		}
 	}
 
-	public String[] parseCommand(String string) {
+	/**
+	 * Tokenizes a String containing multiple arguments formatted shell-style, cognizant of spaces which are escaped or within quotes.
+	 * @param string Shell-style space-separated arguments for Manticore arguments with array input type.
+	 * @return String array suitable to be passed to a ProcessBuilder.
+	 */
+	public String[] tokenizeArrayInput(String string) {
 		final List<Character> WORD_DELIMITERS = Arrays.asList(' ', '\t');
 		final List<Character> QUOTE_CHARACTERS = Arrays.asList('"', '\'');
 		final char ESCAPE_CHARACTER = '\\';
@@ -158,6 +186,9 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		return words.toArray(new String[0]);
 	}
 
+	/**
+	 * @deprecated
+	 */
 	public void noManticoreBinary() {
 		MUILogContentComponent newTabContent = new MUILogContentComponent();
 		newTabContent.logArea.append("No manticore binary found!");
@@ -167,6 +198,10 @@ public class MUILogProvider extends ComponentProviderAdapter {
 			logTabPane.getTabCount() - 1, new MUILogTabComponent(logTabPane, this));
 	}
 
+	/**
+	 * Performs auxiliary actions when closing a tab, including stopping the Manticore instance and removing the tab component from the tab pane.
+	 * @param tabIndex The index of the closed tab in the MUI Log tab pane.
+	 */
 	public void closeLogTab(int tabIndex) {
 		MUILogContentComponent curComp =
 			(MUILogContentComponent) logTabPane.getComponentAt(tabIndex);

--- a/MUI/src/main/java/mui/MUILogProvider.java
+++ b/MUI/src/main/java/mui/MUILogProvider.java
@@ -72,7 +72,7 @@ public class MUILogProvider extends ComponentProviderAdapter {
 		newTabContent.requestFocusInWindow();
 
 	}
-	
+
 	/**
 	 * Structures Manticore argument data input by the user to be compatible with ProcessBuilder.
 	 * @param programPath Path of the binary being analyzed.
@@ -80,7 +80,8 @@ public class MUILogProvider extends ComponentProviderAdapter {
 	 * @param moreArgs Additional Manticore arguments set by the user.
 	 * @return String array suitable to be passed to a ProcessBuilder.
 	 */
-	public String[] buildCommand(String programPath, HashMap<String, JTextField> formOptions, String moreArgs) {
+	public String[] buildCommand(String programPath, HashMap<String, JTextField> formOptions,
+			String moreArgs) {
 		ArrayList<String> f_command = new ArrayList<String>();
 		f_command.add(formOptions.get("{mcore_binary}").getText());
 

--- a/MUI/src/main/java/mui/MUILogTabComponent.java
+++ b/MUI/src/main/java/mui/MUILogTabComponent.java
@@ -6,6 +6,9 @@ import java.awt.event.*;
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicButtonUI;
 
+/**
+ * Provides the component for the Tab itself in the MUI Log tabbed pane, including behaviour when switching and closing tabs.
+ */
 public class MUILogTabComponent extends JPanel {
 	private JTabbedPane parentPane;
 	private MUILogProvider logProvider;
@@ -54,16 +57,27 @@ public class MUILogTabComponent extends JPanel {
 			addActionListener(this);
 		}
 
+		/**
+		 * Closes tab when close button is clicked, and calls additional method to handle auxiliary functions.
+		 * @see MUILogProvider#closeLogTab(int)
+		 */
 		public void actionPerformed(ActionEvent e) {
 			int i = parentPane.indexOfTabComponent(MUILogTabComponent.this);
 			if (i != -1) {
 				logProvider.closeLogTab(i);
 			}
 		}
-
+		
+		/**
+		 * Overrides the updateUI method with no action, since the Tab and thus the Button will be closed on click anyways.
+		 */
+		@Override
 		public void updateUI() {
 		}
 
+		/**
+		 * Natively paints the close button graphic.
+		 */
 		protected void paintComponent(Graphics g) {
 			super.paintComponent(g);
 			Graphics2D g2 = (Graphics2D) g.create();
@@ -82,6 +96,9 @@ public class MUILogTabComponent extends JPanel {
 		}
 	}
 
+	/**
+	 * Handles tab switching, including auxiliary behavior such as reflecting the State List of the newly-focused Manticore instance.
+	 */
 	private final MouseAdapter switchTabMouseAdapter =
 		new MouseAdapter() {
 			@Override
@@ -96,6 +113,9 @@ public class MUILogTabComponent extends JPanel {
 			}
 		};
 
+	/**
+	 * Handles UI changes when mousing over and clicking into the close tab button.
+	 */
 	private final MouseListener closeButtonMouseListener =
 		new MouseAdapter() {
 			public void mouseEntered(MouseEvent e) {

--- a/MUI/src/main/java/mui/MUILogTabComponent.java
+++ b/MUI/src/main/java/mui/MUILogTabComponent.java
@@ -67,7 +67,7 @@ public class MUILogTabComponent extends JPanel {
 				logProvider.closeLogTab(i);
 			}
 		}
-		
+
 		/**
 		 * Overrides the updateUI method with no action, since the Tab and thus the Button will be closed on click anyways.
 		 */

--- a/MUI/src/main/java/mui/MUIPlugin.java
+++ b/MUI/src/main/java/mui/MUIPlugin.java
@@ -24,7 +24,6 @@ import ghidra.framework.plugintool.*;
 import ghidra.framework.plugintool.util.PluginStatus;
 import ghidra.program.model.listing.Program;
 
-/** TODO: Provide class-level documentation that describes what this plugin does. */
 // @formatter:off
 @PluginInfo(
     status = PluginStatus.UNSTABLE,
@@ -45,6 +44,9 @@ public class MUIPlugin extends ProgramPlugin {
 	private DockingAction showLog;
 	private DockingAction showStateList;
 
+	/**
+	 * The main extension constructor, initializes the plugin's components and sets up the "MUI" MenuBar tab.
+	 */
 	public MUIPlugin(PluginTool tool) {
 		super(tool, true, true);
 		String pluginName = getName();

--- a/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -12,6 +12,10 @@ import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.address.Address;
 
+
+/**
+ * Provides functionality to Find/Avoid a specific address via a right-click context menu item in the Listing component.
+ */
 public class MUIPopupMenu extends ListingContextAction {
 
 	private static Program program;
@@ -28,6 +32,10 @@ public class MUIPopupMenu extends ListingContextAction {
 		setupMenu();
 	}
 
+	/**
+	 * Clears color from the Listing component for the specified address.
+	 * @param address The address to clear color from.
+	 */
 	public static void unsetColor(Address address) {
 		ColorizingService service = pluginTool.getService(ColorizingService.class);
 		int tid = program.startTransaction("unsetColor");
@@ -35,6 +43,11 @@ public class MUIPopupMenu extends ListingContextAction {
 		program.endTransaction(tid, true);
 	}
 
+	/**
+	 * Sets color in the Listing component for the specified address.
+	 * @param address The address to clear color from.
+	 * @param color The color to set for the address in the Listing component.
+	 */
 	public static void setColor(Address address, Color color) {
 		ColorizingService service = pluginTool.getService(ColorizingService.class);
 		int tid = program.startTransaction("setColor");
@@ -43,6 +56,9 @@ public class MUIPopupMenu extends ListingContextAction {
 
 	}
 
+	/**
+	 * Displays a warning in the "MUI Setup" component indicating that Find/Avoid backend functionality is currently unimplemented.
+	 */
 	private void updateWarning() {
 		if (findAddresses.isEmpty() && avoidAddresses.isEmpty()) {
 			MUISetupProvider.findAvoidUnimplementedLbl.setVisible(false);
@@ -52,6 +68,9 @@ public class MUIPopupMenu extends ListingContextAction {
 		}
 	}
 
+	/**
+	 * Builds the menu items in the right-click context menu of the Listing component.
+	 */
 	public void setupMenu() {
 		pluginTool.setMenuGroup(new String[] { "MUI" }, "MUI");
 
@@ -109,6 +128,11 @@ public class MUIPopupMenu extends ListingContextAction {
 
 	}
 
+	/** 
+	 * Called once the binary being analyzed in Ghidra has been activated.
+	 * @param p the binary being analyzed in Ghidra
+	 * @see MUIPlugin#programActivated(Program)
+	 */
 	public void setProgram(Program p) {
 		program = p;
 	}

--- a/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -12,7 +12,6 @@ import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.address.Address;
 
-
 /**
  * Provides functionality to Find/Avoid a specific address via a right-click context menu item in the Listing component.
  */

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -2,8 +2,16 @@ package mui;
 
 import java.util.*;
 
+/**
+ * Outlines the key manticore arguments to display for the user, as well as their sensible defaults. Should eventually be deprecated for a more interoperable format.
+ * @see <a href="https://github.com/trailofbits/ManticoreUI/blob/master/mui/settings.py">Binary Ninja plugin equivalent</a>
+ */
 public class MUISettings {
-
+	
+	
+	/**
+	 * Map containing key Manticore arguments and their details including input types, defaults, and descriptions.
+	 */
 	public static Map<String, TreeMap<String, Map<String, Object>[]>> SETTINGS =
 		Map.of(
 			"NATIVE_RUN_SETTINGS",

--- a/MUI/src/main/java/mui/MUISettings.java
+++ b/MUI/src/main/java/mui/MUISettings.java
@@ -7,8 +7,7 @@ import java.util.*;
  * @see <a href="https://github.com/trailofbits/ManticoreUI/blob/master/mui/settings.py">Binary Ninja plugin equivalent</a>
  */
 public class MUISettings {
-	
-	
+
 	/**
 	 * Map containing key Manticore arguments and their details including input types, defaults, and descriptions.
 	 */

--- a/MUI/src/main/java/mui/MUISetupProvider.java
+++ b/MUI/src/main/java/mui/MUISetupProvider.java
@@ -16,6 +16,9 @@ import java.util.Map.Entry;
 
 import javax.swing.*;
 
+/**
+ * Provides the "MUI Setup" component used to set the arguments for and run Manticore.
+ */
 public class MUISetupProvider extends ComponentProviderAdapter {
 
 	private Program program;
@@ -52,6 +55,11 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		stateListProvider = stateList;
 	}
 
+	/**
+	 * Builds the component where key manticore arguments are displayed with dedicated input fields which are loaded with sensible defaults. Arguments include are defined in MUISettings.
+	 * @see MUISettings#SETTINGS
+	 * @throws UnsupportedOperationException
+	 */
 	private void buildFormPanel() throws UnsupportedOperationException {
 		formPanel = new JPanel();
 		formPanel.setLayout(
@@ -102,6 +110,11 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		}
 	}
 
+	/** 
+	 * Creates JTextField for a string/number Manticore argument and adds it to the Setup Panel.
+	 * @param defaultStr The default value of the string/number argument, which should be set in MUISettings.
+	 * @return An editable JTextField through which a user can set a string/number argument.
+	 */
 	private JTextField createStringNumberInput(String defaultStr) {
 		JTextField entry = new JTextField();
 		entry.setText(defaultStr);
@@ -110,6 +123,12 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		return entry;
 	}
 
+	/** 
+	 * Creates JTextField for an array Manticore argument and adds it to the Setup Panel. The user is expected to space-separate each element in the array. Tokenizer supports escaped spaces or spaces within quotes.
+	 * @implNote Should mimic Binary Ninja plugin behavior in future, which would allow for removal of tokenizer.
+	 * @see MUILogProvider#tokenizeArrayInput
+	 * @return An editable JTextField through which a user can set an array argument.
+	 */
 	private JTextField createArrayInput() {
 		// TODO: doesn't handle default param for arrays, but not needed as part of sensible defaults for running manticore on native binaries
 		// for now, same UI as string/num, and we will parse space-separated args
@@ -119,6 +138,11 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		return entry;
 	}
 
+	/** 
+	 * Creates JTextField and file selector dialog (shown by a select button) for a path Manticore argument and adds it to the Setup Panel.
+	 * @param defaultStr The default value of the path argument.
+	 * @return An editable JTextField through which a user can set a path argument.
+	 */
 	private JTextField createPathInput(String defaultStr) {
 		JTextField entry = new JTextField();
 
@@ -166,6 +190,9 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		return entry;
 	}
 
+	/**
+	 * Builds the main component panel which wraps formPanel and includes a JTextArea where user can specify additional args, the Run button, and displays warnings for when user interacts with unsupported Find/Avoid feature.
+	 */
 	private void buildMainPanel() {
 		mainPanel = new JPanel(new BorderLayout());
 		mainPanel.setMinimumSize(new Dimension(900, 500));
@@ -209,6 +236,11 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 		mainPanel.add(bottomPanel, BorderLayout.SOUTH);
 	}
 
+	/** 
+	 * Called once the binary being analyzed in Ghidra has been activated.
+	 * @param p the binary being analyzed in Ghidra
+	 * @see MUIPlugin#programActivated(Program)
+	 */
 	public void setProgram(Program p) {
 		program = p;
 		programPath = program.getExecutablePath();

--- a/MUI/src/main/java/mui/MUIStateListProvider.java
+++ b/MUI/src/main/java/mui/MUIStateListProvider.java
@@ -21,6 +21,9 @@ import ghidra.framework.plugintool.PluginTool;
 import ghidra.util.Msg;
 import mserialize.StateOuterClass;
 
+/**
+ * Provides the "MUI State List" component used to display the State List of the Manticore instance whose MUI Log tab is currently focused.
+ */
 public class MUIStateListProvider extends ComponentProviderAdapter {
 
 	private JPanel mainPanel;
@@ -49,11 +52,17 @@ public class MUIStateListProvider extends ComponentProviderAdapter {
 		setVisible(false);
 	}
 
+	/**
+	 * Builds main component panel which contains the JTree display.
+	 */
 	private void buildMainPanel() {
 		mainPanel = new JPanel(new BorderLayout());
 		mainPanel.add(stateListView, BorderLayout.CENTER);
 	}
 
+	/**
+	 * Builds scrollable tree display with states categorized into the 5 statuses.
+	 */
 	private void buildStateListView() {
 		rootNode =
 			new DefaultMutableTreeNode("States");
@@ -90,12 +99,19 @@ public class MUIStateListProvider extends ComponentProviderAdapter {
 		});
 	}
 
+	/**
+	 * Gracefully updates the Manticore instance whose State List is shown.
+	 * @param runner The new Manticore instance whose State List should be shown.
+	 */
 	public static void changeRunner(ManticoreRunner runner) {
 		clearStateTree();
 		runnerDisplayed = runner;
 		tryUpdate(runnerDisplayed.stateListModel);
 	}
 
+	/**
+	 * Helper method to clear all states from the state tree in preparation for a new update.
+	 */
 	private static void clearStateTree() {
 		activeNode.removeAllChildren();
 		waitingNode.removeAllChildren();
@@ -104,6 +120,10 @@ public class MUIStateListProvider extends ComponentProviderAdapter {
 		erroredNode.removeAllChildren();
 	}
 
+	/**
+	 * Updates the State List UI using the given state list model.
+	 * @param stateListModel Updated State List model.
+	 */
 	public static void tryUpdate(ManticoreStateListModel stateListModel) {
 
 		maxStateId = 0;
@@ -145,6 +165,10 @@ public class MUIStateListProvider extends ComponentProviderAdapter {
 		}
 	}
 
+	/**
+	 * @param st State
+	 * @return Node that can be added to another parent node for the State List UI.
+	 */
 	private static DefaultMutableTreeNode stateToNode(StateOuterClass.State st) {
 		maxStateId = Math.max(maxStateId, st.getId());
 		numsSent.add(st.getId());

--- a/MUI/src/main/java/mui/ManticoreRunner.java
+++ b/MUI/src/main/java/mui/ManticoreRunner.java
@@ -18,6 +18,9 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 
+/**
+ * The class representing each instance of Manticore.
+ */
 public class ManticoreRunner {
 
 	private Boolean isTerminated;
@@ -41,10 +44,18 @@ public class ManticoreRunner {
 		port = 3214;
 	}
 
+	/**
+	 * Gracefully terminates the Manticore process.
+	 */
 	public void stopProc() {
 		isTerminated = true;
 	}
 
+	/**
+	 * Opens a new thread to run an instance of Manticore using the arguments specified.
+	 * @param command Full Manticore command to be passed to ProcessBuilder.
+	 * @param portUsed Chosen port for the Log server (+1 for State server).
+	 */
 	public void callProc(String[] command, int portUsed) {
 
 		stopButton.setEnabled(true);
@@ -151,6 +162,10 @@ public class ManticoreRunner {
 		sw.execute();
 	}
 
+	/**
+	 * Updates the State List shown only if the Log tab of the Manticore instance is currently being viewed.
+	 * @param model Updated model reflecting existing States and their statuses.
+	 */
 	private void updateStateList(ManticoreStateListModel model) {
 		stateListModel = model;
 		if (MUIStateListProvider.runnerDisplayed == this) {

--- a/MUI/src/main/java/mui/ManticoreStateListModel.java
+++ b/MUI/src/main/java/mui/ManticoreStateListModel.java
@@ -4,9 +4,16 @@ import java.util.*;
 
 import mserialize.StateOuterClass;
 
+/**
+ *
+ */
 public class ManticoreStateListModel {
+	
 	public HashMap<StateOuterClass.State.StateType, ArrayList<StateOuterClass.State>> stateList;
 
+	/**
+	 * Maintains a State List with statuses based on the statuses provided by the protobuf message from each Manticore instance's State server.
+	 */
 	public ManticoreStateListModel() {
 		stateList = new HashMap();
 		stateList.put(StateOuterClass.State.StateType.READY,

--- a/MUI/src/main/java/mui/ManticoreStateListModel.java
+++ b/MUI/src/main/java/mui/ManticoreStateListModel.java
@@ -8,7 +8,7 @@ import mserialize.StateOuterClass;
  *
  */
 public class ManticoreStateListModel {
-	
+
 	public HashMap<StateOuterClass.State.StateType, ArrayList<StateOuterClass.State>> stateList;
 
 	/**

--- a/README.md
+++ b/README.md
@@ -3,32 +3,56 @@ MUI support for Ghidra. This is primarily a prototype repository. See the main [
 
 # Usage
 
-At its present form, MUI-Ghidra manifests as three Ghidra components named `MUI Setup` (used to specify args and run Manticore), `MUI Log`, and `MUI State List` (which display Manticore output). 
+At its present form, MUI-Ghidra manifests as three Ghidra components named `MUI Setup` (used to specify args and run Manticore), `MUI Log`, and `MUI State List` (which together display Manticore output). 
 
-1. To run manticore on the current binary, open the `MUI Setup` component via `MUI -> Run Manticore` in the menu.
-
-![image](https://user-images.githubusercontent.com/29654756/150149215-3ade543a-b556-4cb0-b758-acd5a5b9f6d5.png)
-
-2. Fill in manticore and program arguments in the `MUI Setup` component, and click the `Run` Button. Notably, users can specify:
+1. To run Manticore on the current binary, open the `MUI Setup` component via `MUI -> Run Manticore` in the menu.
+2. Fill in Manticore and program arguments in the `MUI Setup` component, and click the `Run` Button. Notably, users can specify:
 - the Manticore binary used (by default, a bundled binary which requires `python3.9` on PATH is used)
 - the port used by Manticore's state server (by default, an open port starting from `3215` will be allocated).
-
-![image](https://user-images.githubusercontent.com/29654756/150147868-fc525a73-72c2-4980-be9a-d2d07fd5f423.png)
-
 3. View log message output and a list of states and their statuses via the `MUI Log`/`MUI State List` components which will be visible on `Run`. Alternatively, you can open the components manually via `MUI -> Show Log / Show State List` in the menu. 
 
-![image](https://user-images.githubusercontent.com/29654756/149968899-ab9b5970-0e24-462f-8c5a-2861aa3ed3ad.png)
-![image](https://user-images.githubusercontent.com/29654756/149969392-4a111c5f-8cf0-45aa-93e5-e0a23ac0a869.png)
+## Components
 
-
-### MUI
+### Setup
 - The `MUI Setup` component allows you to specify key `manticore` arguments
 - You may add additional arguments in the `Extra Manticore Arguments` field at the bottom of the panel
-- Click `Run` to execute the manticore command with your desired arguments
+- Click `Run` to being an instance of Manticore with your desired arguments
+- You may run multiple Manticore instances at once
 
-### MUI Log
+<p align="center">
+    <img src="https://user-images.githubusercontent.com/29654756/151377073-33fa879d-cece-44a8-a18b-216d47f932d1.png" alt="Image" height="400" />
+</p>
+
+### Log
 - At present, `stdout` from `manticore` is output to the log
 - You may stop the execution of manticore and clear the log with the Stop and Clear buttons on the toolbar
+- You can switch between Manticore instances by clicking on their respective log tabs
+- Closing a log tab will stop the execution of the Manticore instance associated with it
+
+<p align="center">
+    <img src="https://user-images.githubusercontent.com/29654756/151377064-e402f91d-eace-48e7-a683-1b8e59bf2127.png" alt="Image" height="400" />
+</p>
+
+### State List
+- The State List displays the states and their statuses of the Manticore instance whose log tab is currently being viewed
+- Switching log tabs will cause the State List to show the state list of the newly-focused Manticore instance
+- You may click on the State statuses to expand a list of States with that status alongside their respective IDs 
+- At present, possible State statuses include `ACTIVE`, `WAITING`, `FORKED`, `COMPLETE`, and `ERRORED`
+
+<p align="center">
+    <img src="https://user-images.githubusercontent.com/29654756/151377036-34cf5aa0-2fdf-43ca-a825-0f4fdec16545.png" alt="Image" height="400" />
+</p>
+
+### Find/Avoid Address
+- Right-clicking on an address/instruction in the Listing component (which displays the analyzed program's disassembly) will reveal two new Menu options: `MUI -> Toggle Find Instruction` and `MUI -> Toggle Avoid Instruction`
+- Setting an address/instruction to `Find` will highlight it Green, and setting it to `Avoid` will highlight it Red
+- However, this feature is currently still **IN DEVELOPMENT** and setting addresses to `Find`/`Avoid` will have no effect
+- A warning in the MUI Setup component should remind users that the feature is still unimplemented if any addresses are set to `Find`/`Avoid`
+
+<p align="center">
+    <img src="https://user-images.githubusercontent.com/29654756/151377865-94167e03-f4a8-45ca-b6a5-5be7d1bf2004.png" alt="Image" height="400" />
+</p>
+
 
 # Building
 


### PR DESCRIPTION
This PR works towards https://github.com/trailofbits/ManticoreUI/issues/33 adds JavaDoc-compatible comments to detail most classes and methods in the plugin, and updates the README to add a section which enumerates the plugin's existing features. Screenshots of components also updated.

extra note: after going through every function again I've identified a few areas where some decent restructuring and code cleanliness work needs to be done, it's something else I can work on during some future downtime I guess

closes https://github.com/trailofbits/ManticoreUI/issues/33