### PR TITLE
Initial EVM Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 MUI/bin/
 MUI/build/
-MUI/dist/
 MUI/lib/*
 **/.classpath
 **/.settings
@@ -9,3 +8,4 @@ MUI/lib/*
 **/.pydevproject
 **/__pycache__/
 **/mcore*/
+**/dist/

--- a/MUI/src/main/grpc/muicore/ManticoreUIGrpc.java
+++ b/MUI/src/main/grpc/muicore/ManticoreUIGrpc.java
@@ -15,6 +15,68 @@ public final class ManticoreUIGrpc {
   public static final String SERVICE_NAME = "muicore.ManticoreUI";
 
   // Static method descriptors that strictly reflect the proto.
+  private static volatile io.grpc.MethodDescriptor<muicore.MUICore.NativeArguments,
+      muicore.MUICore.ManticoreInstance> getStartNativeMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StartNative",
+      requestType = muicore.MUICore.NativeArguments.class,
+      responseType = muicore.MUICore.ManticoreInstance.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<muicore.MUICore.NativeArguments,
+      muicore.MUICore.ManticoreInstance> getStartNativeMethod() {
+    io.grpc.MethodDescriptor<muicore.MUICore.NativeArguments, muicore.MUICore.ManticoreInstance> getStartNativeMethod;
+    if ((getStartNativeMethod = ManticoreUIGrpc.getStartNativeMethod) == null) {
+      synchronized (ManticoreUIGrpc.class) {
+        if ((getStartNativeMethod = ManticoreUIGrpc.getStartNativeMethod) == null) {
+          ManticoreUIGrpc.getStartNativeMethod = getStartNativeMethod =
+              io.grpc.MethodDescriptor.<muicore.MUICore.NativeArguments, muicore.MUICore.ManticoreInstance>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "StartNative"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.NativeArguments.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.ManticoreInstance.getDefaultInstance()))
+              .setSchemaDescriptor(new ManticoreUIMethodDescriptorSupplier("StartNative"))
+              .build();
+        }
+      }
+    }
+    return getStartNativeMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<muicore.MUICore.EVMArguments,
+      muicore.MUICore.ManticoreInstance> getStartEVMMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StartEVM",
+      requestType = muicore.MUICore.EVMArguments.class,
+      responseType = muicore.MUICore.ManticoreInstance.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<muicore.MUICore.EVMArguments,
+      muicore.MUICore.ManticoreInstance> getStartEVMMethod() {
+    io.grpc.MethodDescriptor<muicore.MUICore.EVMArguments, muicore.MUICore.ManticoreInstance> getStartEVMMethod;
+    if ((getStartEVMMethod = ManticoreUIGrpc.getStartEVMMethod) == null) {
+      synchronized (ManticoreUIGrpc.class) {
+        if ((getStartEVMMethod = ManticoreUIGrpc.getStartEVMMethod) == null) {
+          ManticoreUIGrpc.getStartEVMMethod = getStartEVMMethod =
+              io.grpc.MethodDescriptor.<muicore.MUICore.EVMArguments, muicore.MUICore.ManticoreInstance>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "StartEVM"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.EVMArguments.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.ManticoreInstance.getDefaultInstance()))
+              .setSchemaDescriptor(new ManticoreUIMethodDescriptorSupplier("StartEVM"))
+              .build();
+        }
+      }
+    }
+    return getStartEVMMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<muicore.MUICore.ManticoreInstance,
       muicore.MUICore.TerminateResponse> getTerminateMethod;
 
@@ -44,68 +106,6 @@ public final class ManticoreUIGrpc {
       }
     }
     return getTerminateMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<muicore.MUICore.CLIArguments,
-      muicore.MUICore.ManticoreInstance> getStartMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "Start",
-      requestType = muicore.MUICore.CLIArguments.class,
-      responseType = muicore.MUICore.ManticoreInstance.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<muicore.MUICore.CLIArguments,
-      muicore.MUICore.ManticoreInstance> getStartMethod() {
-    io.grpc.MethodDescriptor<muicore.MUICore.CLIArguments, muicore.MUICore.ManticoreInstance> getStartMethod;
-    if ((getStartMethod = ManticoreUIGrpc.getStartMethod) == null) {
-      synchronized (ManticoreUIGrpc.class) {
-        if ((getStartMethod = ManticoreUIGrpc.getStartMethod) == null) {
-          ManticoreUIGrpc.getStartMethod = getStartMethod =
-              io.grpc.MethodDescriptor.<muicore.MUICore.CLIArguments, muicore.MUICore.ManticoreInstance>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Start"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  muicore.MUICore.CLIArguments.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  muicore.MUICore.ManticoreInstance.getDefaultInstance()))
-              .setSchemaDescriptor(new ManticoreUIMethodDescriptorSupplier("Start"))
-              .build();
-        }
-      }
-    }
-    return getStartMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<muicore.MUICore.AddressRequest,
-      muicore.MUICore.TargetResponse> getTargetAddressMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "TargetAddress",
-      requestType = muicore.MUICore.AddressRequest.class,
-      responseType = muicore.MUICore.TargetResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<muicore.MUICore.AddressRequest,
-      muicore.MUICore.TargetResponse> getTargetAddressMethod() {
-    io.grpc.MethodDescriptor<muicore.MUICore.AddressRequest, muicore.MUICore.TargetResponse> getTargetAddressMethod;
-    if ((getTargetAddressMethod = ManticoreUIGrpc.getTargetAddressMethod) == null) {
-      synchronized (ManticoreUIGrpc.class) {
-        if ((getTargetAddressMethod = ManticoreUIGrpc.getTargetAddressMethod) == null) {
-          ManticoreUIGrpc.getTargetAddressMethod = getTargetAddressMethod =
-              io.grpc.MethodDescriptor.<muicore.MUICore.AddressRequest, muicore.MUICore.TargetResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TargetAddress"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  muicore.MUICore.AddressRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  muicore.MUICore.TargetResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new ManticoreUIMethodDescriptorSupplier("TargetAddress"))
-              .build();
-        }
-      }
-    }
-    return getTargetAddressMethod;
   }
 
   private static volatile io.grpc.MethodDescriptor<muicore.MUICore.ManticoreInstance,
@@ -201,6 +201,37 @@ public final class ManticoreUIGrpc {
     return getCheckManticoreRunningMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<muicore.MUICore.AddressRequest,
+      muicore.MUICore.TargetResponse> getTargetAddressNativeMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TargetAddressNative",
+      requestType = muicore.MUICore.AddressRequest.class,
+      responseType = muicore.MUICore.TargetResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<muicore.MUICore.AddressRequest,
+      muicore.MUICore.TargetResponse> getTargetAddressNativeMethod() {
+    io.grpc.MethodDescriptor<muicore.MUICore.AddressRequest, muicore.MUICore.TargetResponse> getTargetAddressNativeMethod;
+    if ((getTargetAddressNativeMethod = ManticoreUIGrpc.getTargetAddressNativeMethod) == null) {
+      synchronized (ManticoreUIGrpc.class) {
+        if ((getTargetAddressNativeMethod = ManticoreUIGrpc.getTargetAddressNativeMethod) == null) {
+          ManticoreUIGrpc.getTargetAddressNativeMethod = getTargetAddressNativeMethod =
+              io.grpc.MethodDescriptor.<muicore.MUICore.AddressRequest, muicore.MUICore.TargetResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TargetAddressNative"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.AddressRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.TargetResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new ManticoreUIMethodDescriptorSupplier("TargetAddressNative"))
+              .build();
+        }
+      }
+    }
+    return getTargetAddressNativeMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -251,23 +282,23 @@ public final class ManticoreUIGrpc {
 
     /**
      */
+    public void startNative(muicore.MUICore.NativeArguments request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getStartNativeMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void startEVM(muicore.MUICore.EVMArguments request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getStartEVMMethod(), responseObserver);
+    }
+
+    /**
+     */
     public void terminate(muicore.MUICore.ManticoreInstance request,
         io.grpc.stub.StreamObserver<muicore.MUICore.TerminateResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTerminateMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void start(muicore.MUICore.CLIArguments request,
-        io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getStartMethod(), responseObserver);
-    }
-
-    /**
-     */
-    public void targetAddress(muicore.MUICore.AddressRequest request,
-        io.grpc.stub.StreamObserver<muicore.MUICore.TargetResponse> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTargetAddressMethod(), responseObserver);
     }
 
     /**
@@ -291,8 +322,29 @@ public final class ManticoreUIGrpc {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getCheckManticoreRunningMethod(), responseObserver);
     }
 
+    /**
+     */
+    public void targetAddressNative(muicore.MUICore.AddressRequest request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.TargetResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTargetAddressNativeMethod(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
+          .addMethod(
+            getStartNativeMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                muicore.MUICore.NativeArguments,
+                muicore.MUICore.ManticoreInstance>(
+                  this, METHODID_START_NATIVE)))
+          .addMethod(
+            getStartEVMMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                muicore.MUICore.EVMArguments,
+                muicore.MUICore.ManticoreInstance>(
+                  this, METHODID_START_EVM)))
           .addMethod(
             getTerminateMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -300,20 +352,6 @@ public final class ManticoreUIGrpc {
                 muicore.MUICore.ManticoreInstance,
                 muicore.MUICore.TerminateResponse>(
                   this, METHODID_TERMINATE)))
-          .addMethod(
-            getStartMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                muicore.MUICore.CLIArguments,
-                muicore.MUICore.ManticoreInstance>(
-                  this, METHODID_START)))
-          .addMethod(
-            getTargetAddressMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                muicore.MUICore.AddressRequest,
-                muicore.MUICore.TargetResponse>(
-                  this, METHODID_TARGET_ADDRESS)))
           .addMethod(
             getGetStateListMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -335,6 +373,13 @@ public final class ManticoreUIGrpc {
                 muicore.MUICore.ManticoreInstance,
                 muicore.MUICore.ManticoreRunningStatus>(
                   this, METHODID_CHECK_MANTICORE_RUNNING)))
+          .addMethod(
+            getTargetAddressNativeMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                muicore.MUICore.AddressRequest,
+                muicore.MUICore.TargetResponse>(
+                  this, METHODID_TARGET_ADDRESS_NATIVE)))
           .build();
     }
   }
@@ -355,26 +400,26 @@ public final class ManticoreUIGrpc {
 
     /**
      */
+    public void startNative(muicore.MUICore.NativeArguments request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getStartNativeMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void startEVM(muicore.MUICore.EVMArguments request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getStartEVMMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
     public void terminate(muicore.MUICore.ManticoreInstance request,
         io.grpc.stub.StreamObserver<muicore.MUICore.TerminateResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getTerminateMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void start(muicore.MUICore.CLIArguments request,
-        io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getStartMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     */
-    public void targetAddress(muicore.MUICore.AddressRequest request,
-        io.grpc.stub.StreamObserver<muicore.MUICore.TargetResponse> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getTargetAddressMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -400,6 +445,14 @@ public final class ManticoreUIGrpc {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getCheckManticoreRunningMethod(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     */
+    public void targetAddressNative(muicore.MUICore.AddressRequest request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.TargetResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getTargetAddressNativeMethod(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -418,23 +471,23 @@ public final class ManticoreUIGrpc {
 
     /**
      */
+    public muicore.MUICore.ManticoreInstance startNative(muicore.MUICore.NativeArguments request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getStartNativeMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public muicore.MUICore.ManticoreInstance startEVM(muicore.MUICore.EVMArguments request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getStartEVMMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
     public muicore.MUICore.TerminateResponse terminate(muicore.MUICore.ManticoreInstance request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getTerminateMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public muicore.MUICore.ManticoreInstance start(muicore.MUICore.CLIArguments request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getStartMethod(), getCallOptions(), request);
-    }
-
-    /**
-     */
-    public muicore.MUICore.TargetResponse targetAddress(muicore.MUICore.AddressRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getTargetAddressMethod(), getCallOptions(), request);
     }
 
     /**
@@ -457,6 +510,13 @@ public final class ManticoreUIGrpc {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getCheckManticoreRunningMethod(), getCallOptions(), request);
     }
+
+    /**
+     */
+    public muicore.MUICore.TargetResponse targetAddressNative(muicore.MUICore.AddressRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getTargetAddressNativeMethod(), getCallOptions(), request);
+    }
   }
 
   /**
@@ -475,26 +535,26 @@ public final class ManticoreUIGrpc {
 
     /**
      */
+    public com.google.common.util.concurrent.ListenableFuture<muicore.MUICore.ManticoreInstance> startNative(
+        muicore.MUICore.NativeArguments request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getStartNativeMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<muicore.MUICore.ManticoreInstance> startEVM(
+        muicore.MUICore.EVMArguments request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getStartEVMMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
     public com.google.common.util.concurrent.ListenableFuture<muicore.MUICore.TerminateResponse> terminate(
         muicore.MUICore.ManticoreInstance request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getTerminateMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<muicore.MUICore.ManticoreInstance> start(
-        muicore.MUICore.CLIArguments request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getStartMethod(), getCallOptions()), request);
-    }
-
-    /**
-     */
-    public com.google.common.util.concurrent.ListenableFuture<muicore.MUICore.TargetResponse> targetAddress(
-        muicore.MUICore.AddressRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getTargetAddressMethod(), getCallOptions()), request);
     }
 
     /**
@@ -520,14 +580,23 @@ public final class ManticoreUIGrpc {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getCheckManticoreRunningMethod(), getCallOptions()), request);
     }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<muicore.MUICore.TargetResponse> targetAddressNative(
+        muicore.MUICore.AddressRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getTargetAddressNativeMethod(), getCallOptions()), request);
+    }
   }
 
-  private static final int METHODID_TERMINATE = 0;
-  private static final int METHODID_START = 1;
-  private static final int METHODID_TARGET_ADDRESS = 2;
+  private static final int METHODID_START_NATIVE = 0;
+  private static final int METHODID_START_EVM = 1;
+  private static final int METHODID_TERMINATE = 2;
   private static final int METHODID_GET_STATE_LIST = 3;
   private static final int METHODID_GET_MESSAGE_LIST = 4;
   private static final int METHODID_CHECK_MANTICORE_RUNNING = 5;
+  private static final int METHODID_TARGET_ADDRESS_NATIVE = 6;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -546,17 +615,17 @@ public final class ManticoreUIGrpc {
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
+        case METHODID_START_NATIVE:
+          serviceImpl.startNative((muicore.MUICore.NativeArguments) request,
+              (io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance>) responseObserver);
+          break;
+        case METHODID_START_EVM:
+          serviceImpl.startEVM((muicore.MUICore.EVMArguments) request,
+              (io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance>) responseObserver);
+          break;
         case METHODID_TERMINATE:
           serviceImpl.terminate((muicore.MUICore.ManticoreInstance) request,
               (io.grpc.stub.StreamObserver<muicore.MUICore.TerminateResponse>) responseObserver);
-          break;
-        case METHODID_START:
-          serviceImpl.start((muicore.MUICore.CLIArguments) request,
-              (io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreInstance>) responseObserver);
-          break;
-        case METHODID_TARGET_ADDRESS:
-          serviceImpl.targetAddress((muicore.MUICore.AddressRequest) request,
-              (io.grpc.stub.StreamObserver<muicore.MUICore.TargetResponse>) responseObserver);
           break;
         case METHODID_GET_STATE_LIST:
           serviceImpl.getStateList((muicore.MUICore.ManticoreInstance) request,
@@ -569,6 +638,10 @@ public final class ManticoreUIGrpc {
         case METHODID_CHECK_MANTICORE_RUNNING:
           serviceImpl.checkManticoreRunning((muicore.MUICore.ManticoreInstance) request,
               (io.grpc.stub.StreamObserver<muicore.MUICore.ManticoreRunningStatus>) responseObserver);
+          break;
+        case METHODID_TARGET_ADDRESS_NATIVE:
+          serviceImpl.targetAddressNative((muicore.MUICore.AddressRequest) request,
+              (io.grpc.stub.StreamObserver<muicore.MUICore.TargetResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -631,12 +704,13 @@ public final class ManticoreUIGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new ManticoreUIFileDescriptorSupplier())
+              .addMethod(getStartNativeMethod())
+              .addMethod(getStartEVMMethod())
               .addMethod(getTerminateMethod())
-              .addMethod(getStartMethod())
-              .addMethod(getTargetAddressMethod())
               .addMethod(getGetStateListMethod())
               .addMethod(getGetMessageListMethod())
               .addMethod(getCheckManticoreRunningMethod())
+              .addMethod(getTargetAddressNativeMethod())
               .build();
         }
       }

--- a/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -76,14 +76,14 @@ public class MUIPopupMenu extends ListingContextAction {
 						findAddresses.remove(selectedAddr);
 						unsetColor(selectedAddr);
 						reqBuilder.setType(AddressRequest.TargetType.CLEAR);
-						MUIPlugin.asyncMUICoreStub.targetAddress(reqBuilder.build(), null);
+						MUIPlugin.asyncMUICoreStub.targetAddressNative(reqBuilder.build(), null);
 					}
 					else {
 						findAddresses.add(selectedAddr);
 						avoidAddresses.remove(selectedAddr);
 						setColor(selectedAddr, Color.GREEN);
 						reqBuilder.setType(AddressRequest.TargetType.FIND);
-						MUIPlugin.asyncMUICoreStub.targetAddress(reqBuilder.build(), null);
+						MUIPlugin.asyncMUICoreStub.targetAddressNative(reqBuilder.build(), null);
 
 					}
 				}
@@ -109,7 +109,7 @@ public class MUIPopupMenu extends ListingContextAction {
 						avoidAddresses.remove(selectedAddr);
 						unsetColor(selectedAddr);
 						reqBuilder.setType(AddressRequest.TargetType.CLEAR);
-						MUIPlugin.asyncMUICoreStub.targetAddress(reqBuilder.build(), null);
+						MUIPlugin.asyncMUICoreStub.targetAddressNative(reqBuilder.build(), null);
 
 					}
 					else {
@@ -117,7 +117,7 @@ public class MUIPopupMenu extends ListingContextAction {
 						findAddresses.remove(selectedAddr);
 						setColor(selectedAddr, Color.RED);
 						reqBuilder.setType(AddressRequest.TargetType.AVOID);
-						MUIPlugin.asyncMUICoreStub.targetAddress(reqBuilder.build(), null);
+						MUIPlugin.asyncMUICoreStub.targetAddressNative(reqBuilder.build(), null);
 					}
 				}
 			};

--- a/MUI/src/main/java/mui/MUISetupProvider.java
+++ b/MUI/src/main/java/mui/MUISetupProvider.java
@@ -4,7 +4,7 @@ import docking.*;
 import ghidra.framework.plugintool.ComponentProviderAdapter;
 import ghidra.framework.plugintool.PluginTool;
 import ghidra.program.model.listing.Program;
-import muicore.MUICore.CLIArguments;
+import muicore.MUICore.NativeArguments;
 
 import java.awt.*;
 import java.awt.event.*;
@@ -193,7 +193,7 @@ public class MUISetupProvider extends ComponentProviderAdapter {
 				@Override
 				public void actionPerformed(ActionEvent e) {
 
-					CLIArguments mcoreArgs = CLIArguments.newBuilder()
+					NativeArguments mcoreArgs = NativeArguments.newBuilder()
 							.setProgramPath(programPath)
 							.addAllBinaryArgs(tokenizeArrayInput(formOptions.get("argv").getText()))
 							.addAllEnvp(tokenizeArrayInput(formOptions.get("env").getText()))

--- a/MUI/src/main/java/mui/ManticoreRunner.java
+++ b/MUI/src/main/java/mui/ManticoreRunner.java
@@ -1,6 +1,6 @@
 package mui;
 
-import muicore.MUICore.CLIArguments;
+import muicore.MUICore.NativeArguments;
 import muicore.MUICore.MUILogMessage;
 import muicore.MUICore.MUIMessageList;
 import muicore.MUICore.MUIState;
@@ -61,9 +61,9 @@ public class ManticoreRunner {
 
 	/**
 	 * Starts Manticore with given arguments.
-	 * @param cliArgs MUICore.CLIArguments object
+	 * @param nativeArgs MUICore.NativeArguments object
 	 */
-	public void startManticore(CLIArguments cliArgs) {
+	public void startManticore(NativeArguments nativeArgs) {
 
 		StreamObserver<ManticoreInstance> startObserver = new StreamObserver<ManticoreInstance>() {
 
@@ -84,7 +84,7 @@ public class ManticoreRunner {
 
 		};
 
-		MUIPlugin.asyncMUICoreStub.start(cliArgs, startObserver);
+		MUIPlugin.asyncMUICoreStub.startNative(nativeArgs, startObserver);
 	}
 
 	public void setManticoreInstance(ManticoreInstance m) {

--- a/MUI/src/main/java/muicore/MUICore.java
+++ b/MUI/src/main/java/muicore/MUICore.java
@@ -7014,28 +7014,40 @@ public final class MUICore {
         getContractNameBytes();
 
     /**
-     * <code>string txlimit = 22;</code>
-     * @return The txlimit.
+     * <code>string solc_bin = 14;</code>
+     * @return The solcBin.
      */
-    java.lang.String getTxlimit();
+    java.lang.String getSolcBin();
     /**
-     * <code>string txlimit = 22;</code>
-     * @return The bytes for txlimit.
+     * <code>string solc_bin = 14;</code>
+     * @return The bytes for solcBin.
      */
     com.google.protobuf.ByteString
-        getTxlimitBytes();
+        getSolcBinBytes();
 
     /**
-     * <code>string txaccount = 23;</code>
-     * @return The txaccount.
+     * <code>string tx_limit = 22;</code>
+     * @return The txLimit.
      */
-    java.lang.String getTxaccount();
+    java.lang.String getTxLimit();
     /**
-     * <code>string txaccount = 23;</code>
-     * @return The bytes for txaccount.
+     * <code>string tx_limit = 22;</code>
+     * @return The bytes for txLimit.
      */
     com.google.protobuf.ByteString
-        getTxaccountBytes();
+        getTxLimitBytes();
+
+    /**
+     * <code>string tx_account = 23;</code>
+     * @return The txAccount.
+     */
+    java.lang.String getTxAccount();
+    /**
+     * <code>string tx_account = 23;</code>
+     * @return The bytes for txAccount.
+     */
+    com.google.protobuf.ByteString
+        getTxAccountBytes();
 
     /**
      * <code>repeated string detectors_to_exclude = 24;</code>
@@ -7063,29 +7075,16 @@ public final class MUICore {
         getDetectorsToExcludeBytes(int index);
 
     /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @return A list containing the additionalFlags.
+     * <code>string additional_flags = 25;</code>
+     * @return The additionalFlags.
      */
-    java.util.List<java.lang.String>
-        getAdditionalFlagsList();
+    java.lang.String getAdditionalFlags();
     /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @return The count of additionalFlags.
-     */
-    int getAdditionalFlagsCount();
-    /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @param index The index of the element to return.
-     * @return The additionalFlags at the given index.
-     */
-    java.lang.String getAdditionalFlags(int index);
-    /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @param index The index of the value to return.
-     * @return The bytes of the additionalFlags at the given index.
+     * <code>string additional_flags = 25;</code>
+     * @return The bytes for additionalFlags.
      */
     com.google.protobuf.ByteString
-        getAdditionalFlagsBytes(int index);
+        getAdditionalFlagsBytes();
   }
   /**
    * Protobuf type {@code muicore.EVMArguments}
@@ -7102,10 +7101,11 @@ public final class MUICore {
     private EVMArguments() {
       contractPath_ = "";
       contractName_ = "";
-      txlimit_ = "";
-      txaccount_ = "";
+      solcBin_ = "";
+      txLimit_ = "";
+      txAccount_ = "";
       detectorsToExclude_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      additionalFlags_ = "";
     }
 
     @java.lang.Override
@@ -7151,16 +7151,22 @@ public final class MUICore {
               contractName_ = s;
               break;
             }
+            case 114: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              solcBin_ = s;
+              break;
+            }
             case 178: {
               java.lang.String s = input.readStringRequireUtf8();
 
-              txlimit_ = s;
+              txLimit_ = s;
               break;
             }
             case 186: {
               java.lang.String s = input.readStringRequireUtf8();
 
-              txaccount_ = s;
+              txAccount_ = s;
               break;
             }
             case 194: {
@@ -7174,11 +7180,8 @@ public final class MUICore {
             }
             case 202: {
               java.lang.String s = input.readStringRequireUtf8();
-              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
-                additionalFlags_ = new com.google.protobuf.LazyStringArrayList();
-                mutable_bitField0_ |= 0x00000002;
-              }
-              additionalFlags_.add(s);
+
+              additionalFlags_ = s;
               break;
             }
             default: {
@@ -7198,9 +7201,6 @@ public final class MUICore {
       } finally {
         if (((mutable_bitField0_ & 0x00000001) != 0)) {
           detectorsToExclude_ = detectorsToExclude_.getUnmodifiableView();
-        }
-        if (((mutable_bitField0_ & 0x00000002) != 0)) {
-          additionalFlags_ = additionalFlags_.getUnmodifiableView();
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -7295,76 +7295,114 @@ public final class MUICore {
       }
     }
 
-    public static final int TXLIMIT_FIELD_NUMBER = 22;
-    private volatile java.lang.Object txlimit_;
+    public static final int SOLC_BIN_FIELD_NUMBER = 14;
+    private volatile java.lang.Object solcBin_;
     /**
-     * <code>string txlimit = 22;</code>
-     * @return The txlimit.
+     * <code>string solc_bin = 14;</code>
+     * @return The solcBin.
      */
     @java.lang.Override
-    public java.lang.String getTxlimit() {
-      java.lang.Object ref = txlimit_;
+    public java.lang.String getSolcBin() {
+      java.lang.Object ref = solcBin_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
-        txlimit_ = s;
+        solcBin_ = s;
         return s;
       }
     }
     /**
-     * <code>string txlimit = 22;</code>
-     * @return The bytes for txlimit.
+     * <code>string solc_bin = 14;</code>
+     * @return The bytes for solcBin.
      */
     @java.lang.Override
     public com.google.protobuf.ByteString
-        getTxlimitBytes() {
-      java.lang.Object ref = txlimit_;
+        getSolcBinBytes() {
+      java.lang.Object ref = solcBin_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        txlimit_ = b;
+        solcBin_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
     }
 
-    public static final int TXACCOUNT_FIELD_NUMBER = 23;
-    private volatile java.lang.Object txaccount_;
+    public static final int TX_LIMIT_FIELD_NUMBER = 22;
+    private volatile java.lang.Object txLimit_;
     /**
-     * <code>string txaccount = 23;</code>
-     * @return The txaccount.
+     * <code>string tx_limit = 22;</code>
+     * @return The txLimit.
      */
     @java.lang.Override
-    public java.lang.String getTxaccount() {
-      java.lang.Object ref = txaccount_;
+    public java.lang.String getTxLimit() {
+      java.lang.Object ref = txLimit_;
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
-        txaccount_ = s;
+        txLimit_ = s;
         return s;
       }
     }
     /**
-     * <code>string txaccount = 23;</code>
-     * @return The bytes for txaccount.
+     * <code>string tx_limit = 22;</code>
+     * @return The bytes for txLimit.
      */
     @java.lang.Override
     public com.google.protobuf.ByteString
-        getTxaccountBytes() {
-      java.lang.Object ref = txaccount_;
+        getTxLimitBytes() {
+      java.lang.Object ref = txLimit_;
       if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
-        txaccount_ = b;
+        txLimit_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TX_ACCOUNT_FIELD_NUMBER = 23;
+    private volatile java.lang.Object txAccount_;
+    /**
+     * <code>string tx_account = 23;</code>
+     * @return The txAccount.
+     */
+    @java.lang.Override
+    public java.lang.String getTxAccount() {
+      java.lang.Object ref = txAccount_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        txAccount_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string tx_account = 23;</code>
+     * @return The bytes for txAccount.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTxAccountBytes() {
+      java.lang.Object ref = txAccount_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        txAccount_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -7407,38 +7445,41 @@ public final class MUICore {
     }
 
     public static final int ADDITIONAL_FLAGS_FIELD_NUMBER = 25;
-    private com.google.protobuf.LazyStringList additionalFlags_;
+    private volatile java.lang.Object additionalFlags_;
     /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @return A list containing the additionalFlags.
+     * <code>string additional_flags = 25;</code>
+     * @return The additionalFlags.
      */
-    public com.google.protobuf.ProtocolStringList
-        getAdditionalFlagsList() {
-      return additionalFlags_;
+    @java.lang.Override
+    public java.lang.String getAdditionalFlags() {
+      java.lang.Object ref = additionalFlags_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        additionalFlags_ = s;
+        return s;
+      }
     }
     /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @return The count of additionalFlags.
+     * <code>string additional_flags = 25;</code>
+     * @return The bytes for additionalFlags.
      */
-    public int getAdditionalFlagsCount() {
-      return additionalFlags_.size();
-    }
-    /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @param index The index of the element to return.
-     * @return The additionalFlags at the given index.
-     */
-    public java.lang.String getAdditionalFlags(int index) {
-      return additionalFlags_.get(index);
-    }
-    /**
-     * <code>repeated string additional_flags = 25;</code>
-     * @param index The index of the value to return.
-     * @return The bytes of the additionalFlags at the given index.
-     */
+    @java.lang.Override
     public com.google.protobuf.ByteString
-        getAdditionalFlagsBytes(int index) {
-      return additionalFlags_.getByteString(index);
+        getAdditionalFlagsBytes() {
+      java.lang.Object ref = additionalFlags_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        additionalFlags_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
     }
 
     private byte memoizedIsInitialized = -1;
@@ -7461,17 +7502,20 @@ public final class MUICore {
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(contractName_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 13, contractName_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txlimit_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 22, txlimit_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(solcBin_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 14, solcBin_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txaccount_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 23, txaccount_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txLimit_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 22, txLimit_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txAccount_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 23, txAccount_);
       }
       for (int i = 0; i < detectorsToExclude_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 24, detectorsToExclude_.getRaw(i));
       }
-      for (int i = 0; i < additionalFlags_.size(); i++) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 25, additionalFlags_.getRaw(i));
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(additionalFlags_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 25, additionalFlags_);
       }
       unknownFields.writeTo(output);
     }
@@ -7488,11 +7532,14 @@ public final class MUICore {
       if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(contractName_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(13, contractName_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txlimit_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(22, txlimit_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(solcBin_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(14, solcBin_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txaccount_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(23, txaccount_);
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txLimit_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(22, txLimit_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txAccount_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(23, txAccount_);
       }
       {
         int dataSize = 0;
@@ -7502,13 +7549,8 @@ public final class MUICore {
         size += dataSize;
         size += 2 * getDetectorsToExcludeList().size();
       }
-      {
-        int dataSize = 0;
-        for (int i = 0; i < additionalFlags_.size(); i++) {
-          dataSize += computeStringSizeNoTag(additionalFlags_.getRaw(i));
-        }
-        size += dataSize;
-        size += 2 * getAdditionalFlagsList().size();
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(additionalFlags_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(25, additionalFlags_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -7529,14 +7571,16 @@ public final class MUICore {
           .equals(other.getContractPath())) return false;
       if (!getContractName()
           .equals(other.getContractName())) return false;
-      if (!getTxlimit()
-          .equals(other.getTxlimit())) return false;
-      if (!getTxaccount()
-          .equals(other.getTxaccount())) return false;
+      if (!getSolcBin()
+          .equals(other.getSolcBin())) return false;
+      if (!getTxLimit()
+          .equals(other.getTxLimit())) return false;
+      if (!getTxAccount()
+          .equals(other.getTxAccount())) return false;
       if (!getDetectorsToExcludeList()
           .equals(other.getDetectorsToExcludeList())) return false;
-      if (!getAdditionalFlagsList()
-          .equals(other.getAdditionalFlagsList())) return false;
+      if (!getAdditionalFlags()
+          .equals(other.getAdditionalFlags())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -7552,18 +7596,18 @@ public final class MUICore {
       hash = (53 * hash) + getContractPath().hashCode();
       hash = (37 * hash) + CONTRACT_NAME_FIELD_NUMBER;
       hash = (53 * hash) + getContractName().hashCode();
-      hash = (37 * hash) + TXLIMIT_FIELD_NUMBER;
-      hash = (53 * hash) + getTxlimit().hashCode();
-      hash = (37 * hash) + TXACCOUNT_FIELD_NUMBER;
-      hash = (53 * hash) + getTxaccount().hashCode();
+      hash = (37 * hash) + SOLC_BIN_FIELD_NUMBER;
+      hash = (53 * hash) + getSolcBin().hashCode();
+      hash = (37 * hash) + TX_LIMIT_FIELD_NUMBER;
+      hash = (53 * hash) + getTxLimit().hashCode();
+      hash = (37 * hash) + TX_ACCOUNT_FIELD_NUMBER;
+      hash = (53 * hash) + getTxAccount().hashCode();
       if (getDetectorsToExcludeCount() > 0) {
         hash = (37 * hash) + DETECTORS_TO_EXCLUDE_FIELD_NUMBER;
         hash = (53 * hash) + getDetectorsToExcludeList().hashCode();
       }
-      if (getAdditionalFlagsCount() > 0) {
-        hash = (37 * hash) + ADDITIONAL_FLAGS_FIELD_NUMBER;
-        hash = (53 * hash) + getAdditionalFlagsList().hashCode();
-      }
+      hash = (37 * hash) + ADDITIONAL_FLAGS_FIELD_NUMBER;
+      hash = (53 * hash) + getAdditionalFlags().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -7701,14 +7745,16 @@ public final class MUICore {
 
         contractName_ = "";
 
-        txlimit_ = "";
+        solcBin_ = "";
 
-        txaccount_ = "";
+        txLimit_ = "";
+
+        txAccount_ = "";
 
         detectorsToExclude_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000001);
-        additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        additionalFlags_ = "";
+
         return this;
       }
 
@@ -7738,17 +7784,14 @@ public final class MUICore {
         int from_bitField0_ = bitField0_;
         result.contractPath_ = contractPath_;
         result.contractName_ = contractName_;
-        result.txlimit_ = txlimit_;
-        result.txaccount_ = txaccount_;
+        result.solcBin_ = solcBin_;
+        result.txLimit_ = txLimit_;
+        result.txAccount_ = txAccount_;
         if (((bitField0_ & 0x00000001) != 0)) {
           detectorsToExclude_ = detectorsToExclude_.getUnmodifiableView();
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.detectorsToExclude_ = detectorsToExclude_;
-        if (((bitField0_ & 0x00000002) != 0)) {
-          additionalFlags_ = additionalFlags_.getUnmodifiableView();
-          bitField0_ = (bitField0_ & ~0x00000002);
-        }
         result.additionalFlags_ = additionalFlags_;
         onBuilt();
         return result;
@@ -7806,12 +7849,16 @@ public final class MUICore {
           contractName_ = other.contractName_;
           onChanged();
         }
-        if (!other.getTxlimit().isEmpty()) {
-          txlimit_ = other.txlimit_;
+        if (!other.getSolcBin().isEmpty()) {
+          solcBin_ = other.solcBin_;
           onChanged();
         }
-        if (!other.getTxaccount().isEmpty()) {
-          txaccount_ = other.txaccount_;
+        if (!other.getTxLimit().isEmpty()) {
+          txLimit_ = other.txLimit_;
+          onChanged();
+        }
+        if (!other.getTxAccount().isEmpty()) {
+          txAccount_ = other.txAccount_;
           onChanged();
         }
         if (!other.detectorsToExclude_.isEmpty()) {
@@ -7824,14 +7871,8 @@ public final class MUICore {
           }
           onChanged();
         }
-        if (!other.additionalFlags_.isEmpty()) {
-          if (additionalFlags_.isEmpty()) {
-            additionalFlags_ = other.additionalFlags_;
-            bitField0_ = (bitField0_ & ~0x00000002);
-          } else {
-            ensureAdditionalFlagsIsMutable();
-            additionalFlags_.addAll(other.additionalFlags_);
-          }
+        if (!other.getAdditionalFlags().isEmpty()) {
+          additionalFlags_ = other.additionalFlags_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -8016,154 +8057,230 @@ public final class MUICore {
         return this;
       }
 
-      private java.lang.Object txlimit_ = "";
+      private java.lang.Object solcBin_ = "";
       /**
-       * <code>string txlimit = 22;</code>
-       * @return The txlimit.
+       * <code>string solc_bin = 14;</code>
+       * @return The solcBin.
        */
-      public java.lang.String getTxlimit() {
-        java.lang.Object ref = txlimit_;
+      public java.lang.String getSolcBin() {
+        java.lang.Object ref = solcBin_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
-          txlimit_ = s;
+          solcBin_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
         }
       }
       /**
-       * <code>string txlimit = 22;</code>
-       * @return The bytes for txlimit.
+       * <code>string solc_bin = 14;</code>
+       * @return The bytes for solcBin.
        */
       public com.google.protobuf.ByteString
-          getTxlimitBytes() {
-        java.lang.Object ref = txlimit_;
+          getSolcBinBytes() {
+        java.lang.Object ref = solcBin_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          txlimit_ = b;
+          solcBin_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
         }
       }
       /**
-       * <code>string txlimit = 22;</code>
-       * @param value The txlimit to set.
+       * <code>string solc_bin = 14;</code>
+       * @param value The solcBin to set.
        * @return This builder for chaining.
        */
-      public Builder setTxlimit(
+      public Builder setSolcBin(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
   
-        txlimit_ = value;
+        solcBin_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>string txlimit = 22;</code>
+       * <code>string solc_bin = 14;</code>
        * @return This builder for chaining.
        */
-      public Builder clearTxlimit() {
+      public Builder clearSolcBin() {
         
-        txlimit_ = getDefaultInstance().getTxlimit();
+        solcBin_ = getDefaultInstance().getSolcBin();
         onChanged();
         return this;
       }
       /**
-       * <code>string txlimit = 22;</code>
-       * @param value The bytes for txlimit to set.
+       * <code>string solc_bin = 14;</code>
+       * @param value The bytes for solcBin to set.
        * @return This builder for chaining.
        */
-      public Builder setTxlimitBytes(
+      public Builder setSolcBinBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
         
-        txlimit_ = value;
+        solcBin_ = value;
         onChanged();
         return this;
       }
 
-      private java.lang.Object txaccount_ = "";
+      private java.lang.Object txLimit_ = "";
       /**
-       * <code>string txaccount = 23;</code>
-       * @return The txaccount.
+       * <code>string tx_limit = 22;</code>
+       * @return The txLimit.
        */
-      public java.lang.String getTxaccount() {
-        java.lang.Object ref = txaccount_;
+      public java.lang.String getTxLimit() {
+        java.lang.Object ref = txLimit_;
         if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
-          txaccount_ = s;
+          txLimit_ = s;
           return s;
         } else {
           return (java.lang.String) ref;
         }
       }
       /**
-       * <code>string txaccount = 23;</code>
-       * @return The bytes for txaccount.
+       * <code>string tx_limit = 22;</code>
+       * @return The bytes for txLimit.
        */
       public com.google.protobuf.ByteString
-          getTxaccountBytes() {
-        java.lang.Object ref = txaccount_;
+          getTxLimitBytes() {
+        java.lang.Object ref = txLimit_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
                   (java.lang.String) ref);
-          txaccount_ = b;
+          txLimit_ = b;
           return b;
         } else {
           return (com.google.protobuf.ByteString) ref;
         }
       }
       /**
-       * <code>string txaccount = 23;</code>
-       * @param value The txaccount to set.
+       * <code>string tx_limit = 22;</code>
+       * @param value The txLimit to set.
        * @return This builder for chaining.
        */
-      public Builder setTxaccount(
+      public Builder setTxLimit(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
   
-        txaccount_ = value;
+        txLimit_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>string txaccount = 23;</code>
+       * <code>string tx_limit = 22;</code>
        * @return This builder for chaining.
        */
-      public Builder clearTxaccount() {
+      public Builder clearTxLimit() {
         
-        txaccount_ = getDefaultInstance().getTxaccount();
+        txLimit_ = getDefaultInstance().getTxLimit();
         onChanged();
         return this;
       }
       /**
-       * <code>string txaccount = 23;</code>
-       * @param value The bytes for txaccount to set.
+       * <code>string tx_limit = 22;</code>
+       * @param value The bytes for txLimit to set.
        * @return This builder for chaining.
        */
-      public Builder setTxaccountBytes(
+      public Builder setTxLimitBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
         
-        txaccount_ = value;
+        txLimit_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object txAccount_ = "";
+      /**
+       * <code>string tx_account = 23;</code>
+       * @return The txAccount.
+       */
+      public java.lang.String getTxAccount() {
+        java.lang.Object ref = txAccount_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          txAccount_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string tx_account = 23;</code>
+       * @return The bytes for txAccount.
+       */
+      public com.google.protobuf.ByteString
+          getTxAccountBytes() {
+        java.lang.Object ref = txAccount_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          txAccount_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string tx_account = 23;</code>
+       * @param value The txAccount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTxAccount(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        txAccount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string tx_account = 23;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTxAccount() {
+        
+        txAccount_ = getDefaultInstance().getTxAccount();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string tx_account = 23;</code>
+       * @param value The bytes for txAccount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTxAccountBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        txAccount_ = value;
         onChanged();
         return this;
       }
@@ -8278,112 +8395,78 @@ public final class MUICore {
         return this;
       }
 
-      private com.google.protobuf.LazyStringList additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-      private void ensureAdditionalFlagsIsMutable() {
-        if (!((bitField0_ & 0x00000002) != 0)) {
-          additionalFlags_ = new com.google.protobuf.LazyStringArrayList(additionalFlags_);
-          bitField0_ |= 0x00000002;
-         }
-      }
+      private java.lang.Object additionalFlags_ = "";
       /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @return A list containing the additionalFlags.
+       * <code>string additional_flags = 25;</code>
+       * @return The additionalFlags.
        */
-      public com.google.protobuf.ProtocolStringList
-          getAdditionalFlagsList() {
-        return additionalFlags_.getUnmodifiableView();
+      public java.lang.String getAdditionalFlags() {
+        java.lang.Object ref = additionalFlags_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          additionalFlags_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
       }
       /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @return The count of additionalFlags.
-       */
-      public int getAdditionalFlagsCount() {
-        return additionalFlags_.size();
-      }
-      /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @param index The index of the element to return.
-       * @return The additionalFlags at the given index.
-       */
-      public java.lang.String getAdditionalFlags(int index) {
-        return additionalFlags_.get(index);
-      }
-      /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @param index The index of the value to return.
-       * @return The bytes of the additionalFlags at the given index.
+       * <code>string additional_flags = 25;</code>
+       * @return The bytes for additionalFlags.
        */
       public com.google.protobuf.ByteString
-          getAdditionalFlagsBytes(int index) {
-        return additionalFlags_.getByteString(index);
+          getAdditionalFlagsBytes() {
+        java.lang.Object ref = additionalFlags_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          additionalFlags_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
       }
       /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @param index The index to set the value at.
+       * <code>string additional_flags = 25;</code>
        * @param value The additionalFlags to set.
        * @return This builder for chaining.
        */
       public Builder setAdditionalFlags(
-          int index, java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  ensureAdditionalFlagsIsMutable();
-        additionalFlags_.set(index, value);
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @param value The additionalFlags to add.
-       * @return This builder for chaining.
-       */
-      public Builder addAdditionalFlags(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
-  ensureAdditionalFlagsIsMutable();
-        additionalFlags_.add(value);
+  
+        additionalFlags_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @param values The additionalFlags to add.
-       * @return This builder for chaining.
-       */
-      public Builder addAllAdditionalFlags(
-          java.lang.Iterable<java.lang.String> values) {
-        ensureAdditionalFlagsIsMutable();
-        com.google.protobuf.AbstractMessageLite.Builder.addAll(
-            values, additionalFlags_);
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>repeated string additional_flags = 25;</code>
+       * <code>string additional_flags = 25;</code>
        * @return This builder for chaining.
        */
       public Builder clearAdditionalFlags() {
-        additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
-        bitField0_ = (bitField0_ & ~0x00000002);
+        
+        additionalFlags_ = getDefaultInstance().getAdditionalFlags();
         onChanged();
         return this;
       }
       /**
-       * <code>repeated string additional_flags = 25;</code>
-       * @param value The bytes of the additionalFlags to add.
+       * <code>string additional_flags = 25;</code>
+       * @param value The bytes for additionalFlags to set.
        * @return This builder for chaining.
        */
-      public Builder addAdditionalFlagsBytes(
+      public Builder setAdditionalFlagsBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
-        ensureAdditionalFlagsIsMutable();
-        additionalFlags_.add(value);
+        
+        additionalFlags_ = value;
         onChanged();
         return this;
       }
@@ -9158,7 +9241,7 @@ public final class MUICore {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>bool success = 14;</code>
+     * <code>bool success = 28;</code>
      * @return The success.
      */
     boolean getSuccess();
@@ -9208,7 +9291,7 @@ public final class MUICore {
             case 0:
               done = true;
               break;
-            case 112: {
+            case 224: {
 
               success_ = input.readBool();
               break;
@@ -9245,10 +9328,10 @@ public final class MUICore {
               muicore.MUICore.TargetResponse.class, muicore.MUICore.TargetResponse.Builder.class);
     }
 
-    public static final int SUCCESS_FIELD_NUMBER = 14;
+    public static final int SUCCESS_FIELD_NUMBER = 28;
     private boolean success_;
     /**
-     * <code>bool success = 14;</code>
+     * <code>bool success = 28;</code>
      * @return The success.
      */
     @java.lang.Override
@@ -9271,7 +9354,7 @@ public final class MUICore {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (success_ != false) {
-        output.writeBool(14, success_);
+        output.writeBool(28, success_);
       }
       unknownFields.writeTo(output);
     }
@@ -9284,7 +9367,7 @@ public final class MUICore {
       size = 0;
       if (success_ != false) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBoolSize(14, success_);
+          .computeBoolSize(28, success_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -9561,7 +9644,7 @@ public final class MUICore {
 
       private boolean success_ ;
       /**
-       * <code>bool success = 14;</code>
+       * <code>bool success = 28;</code>
        * @return The success.
        */
       @java.lang.Override
@@ -9569,7 +9652,7 @@ public final class MUICore {
         return success_;
       }
       /**
-       * <code>bool success = 14;</code>
+       * <code>bool success = 28;</code>
        * @param value The success to set.
        * @return This builder for chaining.
        */
@@ -9580,7 +9663,7 @@ public final class MUICore {
         return this;
       }
       /**
-       * <code>bool success = 14;</code>
+       * <code>bool success = 28;</code>
        * @return This builder for chaining.
        */
       public Builder clearSuccess() {
@@ -10210,30 +10293,30 @@ public final class MUICore {
       "ram_path\030\013 \001(\t\022\023\n\013binary_args\030\020 \003(\t\022\014\n\004e" +
       "nvp\030\021 \003(\t\022\026\n\016symbolic_files\030\022 \003(\t\022\026\n\016con" +
       "crete_start\030\023 \001(\t\022\022\n\nstdin_size\030\024 \001(\t\022\035\n" +
-      "\025additional_mcore_args\030\025 \001(\t\"\230\001\n\014EVMArgu" +
+      "\025additional_mcore_args\030\025 \001(\t\"\254\001\n\014EVMArgu" +
       "ments\022\025\n\rcontract_path\030\014 \001(\t\022\025\n\rcontract" +
-      "_name\030\r \001(\t\022\017\n\007txlimit\030\026 \001(\t\022\021\n\ttxaccoun" +
-      "t\030\027 \001(\t\022\034\n\024detectors_to_exclude\030\030 \003(\t\022\030\n" +
-      "\020additional_flags\030\031 \003(\t\"\201\001\n\016AddressReque" +
-      "st\022\017\n\007address\030\032 \001(\004\0220\n\004type\030\033 \001(\0162\".muic" +
-      "ore.AddressRequest.TargetType\",\n\nTargetT" +
-      "ype\022\010\n\004FIND\020\000\022\t\n\005AVOID\020\001\022\t\n\005CLEAR\020\002\"!\n\016T" +
-      "argetResponse\022\017\n\007success\030\016 \001(\010\",\n\026Mantic" +
-      "oreRunningStatus\022\022\n\nis_running\030\017 \001(\0102\215\004\n" +
-      "\013ManticoreUI\022E\n\013StartNative\022\030.muicore.Na" +
-      "tiveArguments\032\032.muicore.ManticoreInstanc" +
-      "e\"\000\022?\n\010StartEVM\022\025.muicore.EVMArguments\032\032" +
-      ".muicore.ManticoreInstance\"\000\022E\n\tTerminat" +
-      "e\022\032.muicore.ManticoreInstance\032\032.muicore." +
-      "TerminateResponse\"\000\022C\n\014GetStateList\022\032.mu" +
-      "icore.ManticoreInstance\032\025.muicore.MUISta" +
-      "teList\"\000\022G\n\016GetMessageList\022\032.muicore.Man" +
-      "ticoreInstance\032\027.muicore.MUIMessageList\"" +
-      "\000\022V\n\025CheckManticoreRunning\022\032.muicore.Man" +
-      "ticoreInstance\032\037.muicore.ManticoreRunnin" +
-      "gStatus\"\000\022I\n\023TargetAddressNative\022\027.muico" +
-      "re.AddressRequest\032\027.muicore.TargetRespon" +
-      "se\"\000b\006proto3"
+      "_name\030\r \001(\t\022\020\n\010solc_bin\030\016 \001(\t\022\020\n\010tx_limi" +
+      "t\030\026 \001(\t\022\022\n\ntx_account\030\027 \001(\t\022\034\n\024detectors" +
+      "_to_exclude\030\030 \003(\t\022\030\n\020additional_flags\030\031 " +
+      "\001(\t\"\201\001\n\016AddressRequest\022\017\n\007address\030\032 \001(\004\022" +
+      "0\n\004type\030\033 \001(\0162\".muicore.AddressRequest.T" +
+      "argetType\",\n\nTargetType\022\010\n\004FIND\020\000\022\t\n\005AVO" +
+      "ID\020\001\022\t\n\005CLEAR\020\002\"!\n\016TargetResponse\022\017\n\007suc" +
+      "cess\030\034 \001(\010\",\n\026ManticoreRunningStatus\022\022\n\n" +
+      "is_running\030\017 \001(\0102\215\004\n\013ManticoreUI\022E\n\013Star" +
+      "tNative\022\030.muicore.NativeArguments\032\032.muic" +
+      "ore.ManticoreInstance\"\000\022?\n\010StartEVM\022\025.mu" +
+      "icore.EVMArguments\032\032.muicore.ManticoreIn" +
+      "stance\"\000\022E\n\tTerminate\022\032.muicore.Manticor" +
+      "eInstance\032\032.muicore.TerminateResponse\"\000\022" +
+      "C\n\014GetStateList\022\032.muicore.ManticoreInsta" +
+      "nce\032\025.muicore.MUIStateList\"\000\022G\n\016GetMessa" +
+      "geList\022\032.muicore.ManticoreInstance\032\027.mui" +
+      "core.MUIMessageList\"\000\022V\n\025CheckManticoreR" +
+      "unning\022\032.muicore.ManticoreInstance\032\037.mui" +
+      "core.ManticoreRunningStatus\"\000\022I\n\023TargetA" +
+      "ddressNative\022\027.muicore.AddressRequest\032\027." +
+      "muicore.TargetResponse\"\000b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -10286,7 +10369,7 @@ public final class MUICore {
     internal_static_muicore_EVMArguments_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_muicore_EVMArguments_descriptor,
-        new java.lang.String[] { "ContractPath", "ContractName", "Txlimit", "Txaccount", "DetectorsToExclude", "AdditionalFlags", });
+        new java.lang.String[] { "ContractPath", "ContractName", "SolcBin", "TxLimit", "TxAccount", "DetectorsToExclude", "AdditionalFlags", });
     internal_static_muicore_AddressRequest_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_muicore_AddressRequest_fieldAccessorTable = new

--- a/MUI/src/main/java/muicore/MUICore.java
+++ b/MUI/src/main/java/muicore/MUICore.java
@@ -5313,8 +5313,8 @@ public final class MUICore {
 
   }
 
-  public interface CLIArgumentsOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:muicore.CLIArguments)
+  public interface NativeArgumentsOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:muicore.NativeArguments)
       com.google.protobuf.MessageOrBuilder {
 
     /**
@@ -5441,18 +5441,18 @@ public final class MUICore {
         getAdditionalMcoreArgsBytes();
   }
   /**
-   * Protobuf type {@code muicore.CLIArguments}
+   * Protobuf type {@code muicore.NativeArguments}
    */
-  public static final class CLIArguments extends
+  public static final class NativeArguments extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:muicore.CLIArguments)
-      CLIArgumentsOrBuilder {
+      // @@protoc_insertion_point(message_implements:muicore.NativeArguments)
+      NativeArgumentsOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use CLIArguments.newBuilder() to construct.
-    private CLIArguments(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use NativeArguments.newBuilder() to construct.
+    private NativeArguments(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private CLIArguments() {
+    private NativeArguments() {
       programPath_ = "";
       binaryArgs_ = com.google.protobuf.LazyStringArrayList.EMPTY;
       envp_ = com.google.protobuf.LazyStringArrayList.EMPTY;
@@ -5466,7 +5466,7 @@ public final class MUICore {
     @SuppressWarnings({"unused"})
     protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
-      return new CLIArguments();
+      return new NativeArguments();
     }
 
     @java.lang.Override
@@ -5474,7 +5474,7 @@ public final class MUICore {
     getUnknownFields() {
       return this.unknownFields;
     }
-    private CLIArguments(
+    private NativeArguments(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -5574,15 +5574,15 @@ public final class MUICore {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return muicore.MUICore.internal_static_muicore_CLIArguments_descriptor;
+      return muicore.MUICore.internal_static_muicore_NativeArguments_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return muicore.MUICore.internal_static_muicore_CLIArguments_fieldAccessorTable
+      return muicore.MUICore.internal_static_muicore_NativeArguments_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              muicore.MUICore.CLIArguments.class, muicore.MUICore.CLIArguments.Builder.class);
+              muicore.MUICore.NativeArguments.class, muicore.MUICore.NativeArguments.Builder.class);
     }
 
     public static final int PROGRAM_PATH_FIELD_NUMBER = 11;
@@ -5932,10 +5932,10 @@ public final class MUICore {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof muicore.MUICore.CLIArguments)) {
+      if (!(obj instanceof muicore.MUICore.NativeArguments)) {
         return super.equals(obj);
       }
-      muicore.MUICore.CLIArguments other = (muicore.MUICore.CLIArguments) obj;
+      muicore.MUICore.NativeArguments other = (muicore.MUICore.NativeArguments) obj;
 
       if (!getProgramPath()
           .equals(other.getProgramPath())) return false;
@@ -5987,69 +5987,69 @@ public final class MUICore {
       return hash;
     }
 
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(byte[] data)
+    public static muicore.MUICore.NativeArguments parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(java.io.InputStream input)
+    public static muicore.MUICore.NativeArguments parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static muicore.MUICore.CLIArguments parseDelimitedFrom(java.io.InputStream input)
+    public static muicore.MUICore.NativeArguments parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static muicore.MUICore.CLIArguments parseDelimitedFrom(
+    public static muicore.MUICore.NativeArguments parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static muicore.MUICore.CLIArguments parseFrom(
+    public static muicore.MUICore.NativeArguments parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -6062,7 +6062,7 @@ public final class MUICore {
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(muicore.MUICore.CLIArguments prototype) {
+    public static Builder newBuilder(muicore.MUICore.NativeArguments prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -6078,26 +6078,26 @@ public final class MUICore {
       return builder;
     }
     /**
-     * Protobuf type {@code muicore.CLIArguments}
+     * Protobuf type {@code muicore.NativeArguments}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:muicore.CLIArguments)
-        muicore.MUICore.CLIArgumentsOrBuilder {
+        // @@protoc_insertion_point(builder_implements:muicore.NativeArguments)
+        muicore.MUICore.NativeArgumentsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return muicore.MUICore.internal_static_muicore_CLIArguments_descriptor;
+        return muicore.MUICore.internal_static_muicore_NativeArguments_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return muicore.MUICore.internal_static_muicore_CLIArguments_fieldAccessorTable
+        return muicore.MUICore.internal_static_muicore_NativeArguments_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                muicore.MUICore.CLIArguments.class, muicore.MUICore.CLIArguments.Builder.class);
+                muicore.MUICore.NativeArguments.class, muicore.MUICore.NativeArguments.Builder.class);
       }
 
-      // Construct using muicore.MUICore.CLIArguments.newBuilder()
+      // Construct using muicore.MUICore.NativeArguments.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -6135,17 +6135,17 @@ public final class MUICore {
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return muicore.MUICore.internal_static_muicore_CLIArguments_descriptor;
+        return muicore.MUICore.internal_static_muicore_NativeArguments_descriptor;
       }
 
       @java.lang.Override
-      public muicore.MUICore.CLIArguments getDefaultInstanceForType() {
-        return muicore.MUICore.CLIArguments.getDefaultInstance();
+      public muicore.MUICore.NativeArguments getDefaultInstanceForType() {
+        return muicore.MUICore.NativeArguments.getDefaultInstance();
       }
 
       @java.lang.Override
-      public muicore.MUICore.CLIArguments build() {
-        muicore.MUICore.CLIArguments result = buildPartial();
+      public muicore.MUICore.NativeArguments build() {
+        muicore.MUICore.NativeArguments result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -6153,8 +6153,8 @@ public final class MUICore {
       }
 
       @java.lang.Override
-      public muicore.MUICore.CLIArguments buildPartial() {
-        muicore.MUICore.CLIArguments result = new muicore.MUICore.CLIArguments(this);
+      public muicore.MUICore.NativeArguments buildPartial() {
+        muicore.MUICore.NativeArguments result = new muicore.MUICore.NativeArguments(this);
         int from_bitField0_ = bitField0_;
         result.programPath_ = programPath_;
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -6213,16 +6213,16 @@ public final class MUICore {
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof muicore.MUICore.CLIArguments) {
-          return mergeFrom((muicore.MUICore.CLIArguments)other);
+        if (other instanceof muicore.MUICore.NativeArguments) {
+          return mergeFrom((muicore.MUICore.NativeArguments)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(muicore.MUICore.CLIArguments other) {
-        if (other == muicore.MUICore.CLIArguments.getDefaultInstance()) return this;
+      public Builder mergeFrom(muicore.MUICore.NativeArguments other) {
+        if (other == muicore.MUICore.NativeArguments.getDefaultInstance()) return this;
         if (!other.getProgramPath().isEmpty()) {
           programPath_ = other.programPath_;
           onChanged();
@@ -6284,11 +6284,11 @@ public final class MUICore {
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        muicore.MUICore.CLIArguments parsedMessage = null;
+        muicore.MUICore.NativeArguments parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (muicore.MUICore.CLIArguments) e.getUnfinishedMessage();
+          parsedMessage = (muicore.MUICore.NativeArguments) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -6945,41 +6945,1496 @@ public final class MUICore {
       }
 
 
-      // @@protoc_insertion_point(builder_scope:muicore.CLIArguments)
+      // @@protoc_insertion_point(builder_scope:muicore.NativeArguments)
     }
 
-    // @@protoc_insertion_point(class_scope:muicore.CLIArguments)
-    private static final muicore.MUICore.CLIArguments DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:muicore.NativeArguments)
+    private static final muicore.MUICore.NativeArguments DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new muicore.MUICore.CLIArguments();
+      DEFAULT_INSTANCE = new muicore.MUICore.NativeArguments();
     }
 
-    public static muicore.MUICore.CLIArguments getDefaultInstance() {
+    public static muicore.MUICore.NativeArguments getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<CLIArguments>
-        PARSER = new com.google.protobuf.AbstractParser<CLIArguments>() {
+    private static final com.google.protobuf.Parser<NativeArguments>
+        PARSER = new com.google.protobuf.AbstractParser<NativeArguments>() {
       @java.lang.Override
-      public CLIArguments parsePartialFrom(
+      public NativeArguments parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CLIArguments(input, extensionRegistry);
+        return new NativeArguments(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<CLIArguments> parser() {
+    public static com.google.protobuf.Parser<NativeArguments> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<CLIArguments> getParserForType() {
+    public com.google.protobuf.Parser<NativeArguments> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public muicore.MUICore.CLIArguments getDefaultInstanceForType() {
+    public muicore.MUICore.NativeArguments getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface EVMArgumentsOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:muicore.EVMArguments)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string contract_path = 12;</code>
+     * @return The contractPath.
+     */
+    java.lang.String getContractPath();
+    /**
+     * <code>string contract_path = 12;</code>
+     * @return The bytes for contractPath.
+     */
+    com.google.protobuf.ByteString
+        getContractPathBytes();
+
+    /**
+     * <code>string contract_name = 13;</code>
+     * @return The contractName.
+     */
+    java.lang.String getContractName();
+    /**
+     * <code>string contract_name = 13;</code>
+     * @return The bytes for contractName.
+     */
+    com.google.protobuf.ByteString
+        getContractNameBytes();
+
+    /**
+     * <code>string txlimit = 22;</code>
+     * @return The txlimit.
+     */
+    java.lang.String getTxlimit();
+    /**
+     * <code>string txlimit = 22;</code>
+     * @return The bytes for txlimit.
+     */
+    com.google.protobuf.ByteString
+        getTxlimitBytes();
+
+    /**
+     * <code>string txaccount = 23;</code>
+     * @return The txaccount.
+     */
+    java.lang.String getTxaccount();
+    /**
+     * <code>string txaccount = 23;</code>
+     * @return The bytes for txaccount.
+     */
+    com.google.protobuf.ByteString
+        getTxaccountBytes();
+
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @return A list containing the detectorsToExclude.
+     */
+    java.util.List<java.lang.String>
+        getDetectorsToExcludeList();
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @return The count of detectorsToExclude.
+     */
+    int getDetectorsToExcludeCount();
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @param index The index of the element to return.
+     * @return The detectorsToExclude at the given index.
+     */
+    java.lang.String getDetectorsToExclude(int index);
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the detectorsToExclude at the given index.
+     */
+    com.google.protobuf.ByteString
+        getDetectorsToExcludeBytes(int index);
+
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @return A list containing the additionalFlags.
+     */
+    java.util.List<java.lang.String>
+        getAdditionalFlagsList();
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @return The count of additionalFlags.
+     */
+    int getAdditionalFlagsCount();
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @param index The index of the element to return.
+     * @return The additionalFlags at the given index.
+     */
+    java.lang.String getAdditionalFlags(int index);
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the additionalFlags at the given index.
+     */
+    com.google.protobuf.ByteString
+        getAdditionalFlagsBytes(int index);
+  }
+  /**
+   * Protobuf type {@code muicore.EVMArguments}
+   */
+  public static final class EVMArguments extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:muicore.EVMArguments)
+      EVMArgumentsOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use EVMArguments.newBuilder() to construct.
+    private EVMArguments(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private EVMArguments() {
+      contractPath_ = "";
+      contractName_ = "";
+      txlimit_ = "";
+      txaccount_ = "";
+      detectorsToExclude_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new EVMArguments();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private EVMArguments(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 98: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              contractPath_ = s;
+              break;
+            }
+            case 106: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              contractName_ = s;
+              break;
+            }
+            case 178: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              txlimit_ = s;
+              break;
+            }
+            case 186: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              txaccount_ = s;
+              break;
+            }
+            case 194: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                detectorsToExclude_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              detectorsToExclude_.add(s);
+              break;
+            }
+            case 202: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000002) != 0)) {
+                additionalFlags_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              additionalFlags_.add(s);
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
+          detectorsToExclude_ = detectorsToExclude_.getUnmodifiableView();
+        }
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
+          additionalFlags_ = additionalFlags_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return muicore.MUICore.internal_static_muicore_EVMArguments_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return muicore.MUICore.internal_static_muicore_EVMArguments_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              muicore.MUICore.EVMArguments.class, muicore.MUICore.EVMArguments.Builder.class);
+    }
+
+    public static final int CONTRACT_PATH_FIELD_NUMBER = 12;
+    private volatile java.lang.Object contractPath_;
+    /**
+     * <code>string contract_path = 12;</code>
+     * @return The contractPath.
+     */
+    @java.lang.Override
+    public java.lang.String getContractPath() {
+      java.lang.Object ref = contractPath_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        contractPath_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string contract_path = 12;</code>
+     * @return The bytes for contractPath.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getContractPathBytes() {
+      java.lang.Object ref = contractPath_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        contractPath_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CONTRACT_NAME_FIELD_NUMBER = 13;
+    private volatile java.lang.Object contractName_;
+    /**
+     * <code>string contract_name = 13;</code>
+     * @return The contractName.
+     */
+    @java.lang.Override
+    public java.lang.String getContractName() {
+      java.lang.Object ref = contractName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        contractName_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string contract_name = 13;</code>
+     * @return The bytes for contractName.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getContractNameBytes() {
+      java.lang.Object ref = contractName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        contractName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TXLIMIT_FIELD_NUMBER = 22;
+    private volatile java.lang.Object txlimit_;
+    /**
+     * <code>string txlimit = 22;</code>
+     * @return The txlimit.
+     */
+    @java.lang.Override
+    public java.lang.String getTxlimit() {
+      java.lang.Object ref = txlimit_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        txlimit_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string txlimit = 22;</code>
+     * @return The bytes for txlimit.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTxlimitBytes() {
+      java.lang.Object ref = txlimit_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        txlimit_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int TXACCOUNT_FIELD_NUMBER = 23;
+    private volatile java.lang.Object txaccount_;
+    /**
+     * <code>string txaccount = 23;</code>
+     * @return The txaccount.
+     */
+    @java.lang.Override
+    public java.lang.String getTxaccount() {
+      java.lang.Object ref = txaccount_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        txaccount_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string txaccount = 23;</code>
+     * @return The bytes for txaccount.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getTxaccountBytes() {
+      java.lang.Object ref = txaccount_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        txaccount_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int DETECTORS_TO_EXCLUDE_FIELD_NUMBER = 24;
+    private com.google.protobuf.LazyStringList detectorsToExclude_;
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @return A list containing the detectorsToExclude.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getDetectorsToExcludeList() {
+      return detectorsToExclude_;
+    }
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @return The count of detectorsToExclude.
+     */
+    public int getDetectorsToExcludeCount() {
+      return detectorsToExclude_.size();
+    }
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @param index The index of the element to return.
+     * @return The detectorsToExclude at the given index.
+     */
+    public java.lang.String getDetectorsToExclude(int index) {
+      return detectorsToExclude_.get(index);
+    }
+    /**
+     * <code>repeated string detectors_to_exclude = 24;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the detectorsToExclude at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getDetectorsToExcludeBytes(int index) {
+      return detectorsToExclude_.getByteString(index);
+    }
+
+    public static final int ADDITIONAL_FLAGS_FIELD_NUMBER = 25;
+    private com.google.protobuf.LazyStringList additionalFlags_;
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @return A list containing the additionalFlags.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getAdditionalFlagsList() {
+      return additionalFlags_;
+    }
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @return The count of additionalFlags.
+     */
+    public int getAdditionalFlagsCount() {
+      return additionalFlags_.size();
+    }
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @param index The index of the element to return.
+     * @return The additionalFlags at the given index.
+     */
+    public java.lang.String getAdditionalFlags(int index) {
+      return additionalFlags_.get(index);
+    }
+    /**
+     * <code>repeated string additional_flags = 25;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the additionalFlags at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getAdditionalFlagsBytes(int index) {
+      return additionalFlags_.getByteString(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(contractPath_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 12, contractPath_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(contractName_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 13, contractName_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txlimit_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 22, txlimit_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txaccount_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 23, txaccount_);
+      }
+      for (int i = 0; i < detectorsToExclude_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 24, detectorsToExclude_.getRaw(i));
+      }
+      for (int i = 0; i < additionalFlags_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 25, additionalFlags_.getRaw(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(contractPath_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(12, contractPath_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(contractName_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(13, contractName_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txlimit_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(22, txlimit_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(txaccount_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(23, txaccount_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < detectorsToExclude_.size(); i++) {
+          dataSize += computeStringSizeNoTag(detectorsToExclude_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getDetectorsToExcludeList().size();
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < additionalFlags_.size(); i++) {
+          dataSize += computeStringSizeNoTag(additionalFlags_.getRaw(i));
+        }
+        size += dataSize;
+        size += 2 * getAdditionalFlagsList().size();
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof muicore.MUICore.EVMArguments)) {
+        return super.equals(obj);
+      }
+      muicore.MUICore.EVMArguments other = (muicore.MUICore.EVMArguments) obj;
+
+      if (!getContractPath()
+          .equals(other.getContractPath())) return false;
+      if (!getContractName()
+          .equals(other.getContractName())) return false;
+      if (!getTxlimit()
+          .equals(other.getTxlimit())) return false;
+      if (!getTxaccount()
+          .equals(other.getTxaccount())) return false;
+      if (!getDetectorsToExcludeList()
+          .equals(other.getDetectorsToExcludeList())) return false;
+      if (!getAdditionalFlagsList()
+          .equals(other.getAdditionalFlagsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + CONTRACT_PATH_FIELD_NUMBER;
+      hash = (53 * hash) + getContractPath().hashCode();
+      hash = (37 * hash) + CONTRACT_NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getContractName().hashCode();
+      hash = (37 * hash) + TXLIMIT_FIELD_NUMBER;
+      hash = (53 * hash) + getTxlimit().hashCode();
+      hash = (37 * hash) + TXACCOUNT_FIELD_NUMBER;
+      hash = (53 * hash) + getTxaccount().hashCode();
+      if (getDetectorsToExcludeCount() > 0) {
+        hash = (37 * hash) + DETECTORS_TO_EXCLUDE_FIELD_NUMBER;
+        hash = (53 * hash) + getDetectorsToExcludeList().hashCode();
+      }
+      if (getAdditionalFlagsCount() > 0) {
+        hash = (37 * hash) + ADDITIONAL_FLAGS_FIELD_NUMBER;
+        hash = (53 * hash) + getAdditionalFlagsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static muicore.MUICore.EVMArguments parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static muicore.MUICore.EVMArguments parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.EVMArguments parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.EVMArguments parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(muicore.MUICore.EVMArguments prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code muicore.EVMArguments}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:muicore.EVMArguments)
+        muicore.MUICore.EVMArgumentsOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return muicore.MUICore.internal_static_muicore_EVMArguments_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return muicore.MUICore.internal_static_muicore_EVMArguments_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                muicore.MUICore.EVMArguments.class, muicore.MUICore.EVMArguments.Builder.class);
+      }
+
+      // Construct using muicore.MUICore.EVMArguments.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        contractPath_ = "";
+
+        contractName_ = "";
+
+        txlimit_ = "";
+
+        txaccount_ = "";
+
+        detectorsToExclude_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return muicore.MUICore.internal_static_muicore_EVMArguments_descriptor;
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.EVMArguments getDefaultInstanceForType() {
+        return muicore.MUICore.EVMArguments.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.EVMArguments build() {
+        muicore.MUICore.EVMArguments result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.EVMArguments buildPartial() {
+        muicore.MUICore.EVMArguments result = new muicore.MUICore.EVMArguments(this);
+        int from_bitField0_ = bitField0_;
+        result.contractPath_ = contractPath_;
+        result.contractName_ = contractName_;
+        result.txlimit_ = txlimit_;
+        result.txaccount_ = txaccount_;
+        if (((bitField0_ & 0x00000001) != 0)) {
+          detectorsToExclude_ = detectorsToExclude_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.detectorsToExclude_ = detectorsToExclude_;
+        if (((bitField0_ & 0x00000002) != 0)) {
+          additionalFlags_ = additionalFlags_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        }
+        result.additionalFlags_ = additionalFlags_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof muicore.MUICore.EVMArguments) {
+          return mergeFrom((muicore.MUICore.EVMArguments)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(muicore.MUICore.EVMArguments other) {
+        if (other == muicore.MUICore.EVMArguments.getDefaultInstance()) return this;
+        if (!other.getContractPath().isEmpty()) {
+          contractPath_ = other.contractPath_;
+          onChanged();
+        }
+        if (!other.getContractName().isEmpty()) {
+          contractName_ = other.contractName_;
+          onChanged();
+        }
+        if (!other.getTxlimit().isEmpty()) {
+          txlimit_ = other.txlimit_;
+          onChanged();
+        }
+        if (!other.getTxaccount().isEmpty()) {
+          txaccount_ = other.txaccount_;
+          onChanged();
+        }
+        if (!other.detectorsToExclude_.isEmpty()) {
+          if (detectorsToExclude_.isEmpty()) {
+            detectorsToExclude_ = other.detectorsToExclude_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureDetectorsToExcludeIsMutable();
+            detectorsToExclude_.addAll(other.detectorsToExclude_);
+          }
+          onChanged();
+        }
+        if (!other.additionalFlags_.isEmpty()) {
+          if (additionalFlags_.isEmpty()) {
+            additionalFlags_ = other.additionalFlags_;
+            bitField0_ = (bitField0_ & ~0x00000002);
+          } else {
+            ensureAdditionalFlagsIsMutable();
+            additionalFlags_.addAll(other.additionalFlags_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        muicore.MUICore.EVMArguments parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (muicore.MUICore.EVMArguments) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object contractPath_ = "";
+      /**
+       * <code>string contract_path = 12;</code>
+       * @return The contractPath.
+       */
+      public java.lang.String getContractPath() {
+        java.lang.Object ref = contractPath_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          contractPath_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string contract_path = 12;</code>
+       * @return The bytes for contractPath.
+       */
+      public com.google.protobuf.ByteString
+          getContractPathBytes() {
+        java.lang.Object ref = contractPath_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          contractPath_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string contract_path = 12;</code>
+       * @param value The contractPath to set.
+       * @return This builder for chaining.
+       */
+      public Builder setContractPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        contractPath_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string contract_path = 12;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearContractPath() {
+        
+        contractPath_ = getDefaultInstance().getContractPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string contract_path = 12;</code>
+       * @param value The bytes for contractPath to set.
+       * @return This builder for chaining.
+       */
+      public Builder setContractPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        contractPath_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object contractName_ = "";
+      /**
+       * <code>string contract_name = 13;</code>
+       * @return The contractName.
+       */
+      public java.lang.String getContractName() {
+        java.lang.Object ref = contractName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          contractName_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string contract_name = 13;</code>
+       * @return The bytes for contractName.
+       */
+      public com.google.protobuf.ByteString
+          getContractNameBytes() {
+        java.lang.Object ref = contractName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          contractName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string contract_name = 13;</code>
+       * @param value The contractName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setContractName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        contractName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string contract_name = 13;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearContractName() {
+        
+        contractName_ = getDefaultInstance().getContractName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string contract_name = 13;</code>
+       * @param value The bytes for contractName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setContractNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        contractName_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object txlimit_ = "";
+      /**
+       * <code>string txlimit = 22;</code>
+       * @return The txlimit.
+       */
+      public java.lang.String getTxlimit() {
+        java.lang.Object ref = txlimit_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          txlimit_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string txlimit = 22;</code>
+       * @return The bytes for txlimit.
+       */
+      public com.google.protobuf.ByteString
+          getTxlimitBytes() {
+        java.lang.Object ref = txlimit_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          txlimit_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string txlimit = 22;</code>
+       * @param value The txlimit to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTxlimit(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        txlimit_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string txlimit = 22;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTxlimit() {
+        
+        txlimit_ = getDefaultInstance().getTxlimit();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string txlimit = 22;</code>
+       * @param value The bytes for txlimit to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTxlimitBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        txlimit_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object txaccount_ = "";
+      /**
+       * <code>string txaccount = 23;</code>
+       * @return The txaccount.
+       */
+      public java.lang.String getTxaccount() {
+        java.lang.Object ref = txaccount_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          txaccount_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string txaccount = 23;</code>
+       * @return The bytes for txaccount.
+       */
+      public com.google.protobuf.ByteString
+          getTxaccountBytes() {
+        java.lang.Object ref = txaccount_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          txaccount_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string txaccount = 23;</code>
+       * @param value The txaccount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTxaccount(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        txaccount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string txaccount = 23;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearTxaccount() {
+        
+        txaccount_ = getDefaultInstance().getTxaccount();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string txaccount = 23;</code>
+       * @param value The bytes for txaccount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setTxaccountBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        txaccount_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList detectorsToExclude_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureDetectorsToExcludeIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          detectorsToExclude_ = new com.google.protobuf.LazyStringArrayList(detectorsToExclude_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @return A list containing the detectorsToExclude.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getDetectorsToExcludeList() {
+        return detectorsToExclude_.getUnmodifiableView();
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @return The count of detectorsToExclude.
+       */
+      public int getDetectorsToExcludeCount() {
+        return detectorsToExclude_.size();
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @param index The index of the element to return.
+       * @return The detectorsToExclude at the given index.
+       */
+      public java.lang.String getDetectorsToExclude(int index) {
+        return detectorsToExclude_.get(index);
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the detectorsToExclude at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getDetectorsToExcludeBytes(int index) {
+        return detectorsToExclude_.getByteString(index);
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @param index The index to set the value at.
+       * @param value The detectorsToExclude to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDetectorsToExclude(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureDetectorsToExcludeIsMutable();
+        detectorsToExclude_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @param value The detectorsToExclude to add.
+       * @return This builder for chaining.
+       */
+      public Builder addDetectorsToExclude(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureDetectorsToExcludeIsMutable();
+        detectorsToExclude_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @param values The detectorsToExclude to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllDetectorsToExclude(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureDetectorsToExcludeIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, detectorsToExclude_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearDetectorsToExclude() {
+        detectorsToExclude_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string detectors_to_exclude = 24;</code>
+       * @param value The bytes of the detectorsToExclude to add.
+       * @return This builder for chaining.
+       */
+      public Builder addDetectorsToExcludeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureDetectorsToExcludeIsMutable();
+        detectorsToExclude_.add(value);
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureAdditionalFlagsIsMutable() {
+        if (!((bitField0_ & 0x00000002) != 0)) {
+          additionalFlags_ = new com.google.protobuf.LazyStringArrayList(additionalFlags_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @return A list containing the additionalFlags.
+       */
+      public com.google.protobuf.ProtocolStringList
+          getAdditionalFlagsList() {
+        return additionalFlags_.getUnmodifiableView();
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @return The count of additionalFlags.
+       */
+      public int getAdditionalFlagsCount() {
+        return additionalFlags_.size();
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @param index The index of the element to return.
+       * @return The additionalFlags at the given index.
+       */
+      public java.lang.String getAdditionalFlags(int index) {
+        return additionalFlags_.get(index);
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @param index The index of the value to return.
+       * @return The bytes of the additionalFlags at the given index.
+       */
+      public com.google.protobuf.ByteString
+          getAdditionalFlagsBytes(int index) {
+        return additionalFlags_.getByteString(index);
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @param index The index to set the value at.
+       * @param value The additionalFlags to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAdditionalFlags(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAdditionalFlagsIsMutable();
+        additionalFlags_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @param value The additionalFlags to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAdditionalFlags(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureAdditionalFlagsIsMutable();
+        additionalFlags_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @param values The additionalFlags to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAllAdditionalFlags(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureAdditionalFlagsIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, additionalFlags_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAdditionalFlags() {
+        additionalFlags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>repeated string additional_flags = 25;</code>
+       * @param value The bytes of the additionalFlags to add.
+       * @return This builder for chaining.
+       */
+      public Builder addAdditionalFlagsBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureAdditionalFlagsIsMutable();
+        additionalFlags_.add(value);
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:muicore.EVMArguments)
+    }
+
+    // @@protoc_insertion_point(class_scope:muicore.EVMArguments)
+    private static final muicore.MUICore.EVMArguments DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new muicore.MUICore.EVMArguments();
+    }
+
+    public static muicore.MUICore.EVMArguments getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<EVMArguments>
+        PARSER = new com.google.protobuf.AbstractParser<EVMArguments>() {
+      @java.lang.Override
+      public EVMArguments parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new EVMArguments(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<EVMArguments> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<EVMArguments> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public muicore.MUICore.EVMArguments getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -6990,18 +8445,18 @@ public final class MUICore {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>uint64 address = 12;</code>
+     * <code>uint64 address = 26;</code>
      * @return The address.
      */
     long getAddress();
 
     /**
-     * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+     * <code>.muicore.AddressRequest.TargetType type = 27;</code>
      * @return The enum numeric value on the wire for type.
      */
     int getTypeValue();
     /**
-     * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+     * <code>.muicore.AddressRequest.TargetType type = 27;</code>
      * @return The type.
      */
     muicore.MUICore.AddressRequest.TargetType getType();
@@ -7052,12 +8507,12 @@ public final class MUICore {
             case 0:
               done = true;
               break;
-            case 96: {
+            case 208: {
 
               address_ = input.readUInt64();
               break;
             }
-            case 104: {
+            case 216: {
               int rawValue = input.readEnum();
 
               type_ = rawValue;
@@ -7212,10 +8667,10 @@ public final class MUICore {
       // @@protoc_insertion_point(enum_scope:muicore.AddressRequest.TargetType)
     }
 
-    public static final int ADDRESS_FIELD_NUMBER = 12;
+    public static final int ADDRESS_FIELD_NUMBER = 26;
     private long address_;
     /**
-     * <code>uint64 address = 12;</code>
+     * <code>uint64 address = 26;</code>
      * @return The address.
      */
     @java.lang.Override
@@ -7223,17 +8678,17 @@ public final class MUICore {
       return address_;
     }
 
-    public static final int TYPE_FIELD_NUMBER = 13;
+    public static final int TYPE_FIELD_NUMBER = 27;
     private int type_;
     /**
-     * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+     * <code>.muicore.AddressRequest.TargetType type = 27;</code>
      * @return The enum numeric value on the wire for type.
      */
     @java.lang.Override public int getTypeValue() {
       return type_;
     }
     /**
-     * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+     * <code>.muicore.AddressRequest.TargetType type = 27;</code>
      * @return The type.
      */
     @java.lang.Override public muicore.MUICore.AddressRequest.TargetType getType() {
@@ -7257,10 +8712,10 @@ public final class MUICore {
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (address_ != 0L) {
-        output.writeUInt64(12, address_);
+        output.writeUInt64(26, address_);
       }
       if (type_ != muicore.MUICore.AddressRequest.TargetType.FIND.getNumber()) {
-        output.writeEnum(13, type_);
+        output.writeEnum(27, type_);
       }
       unknownFields.writeTo(output);
     }
@@ -7273,11 +8728,11 @@ public final class MUICore {
       size = 0;
       if (address_ != 0L) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(12, address_);
+          .computeUInt64Size(26, address_);
       }
       if (type_ != muicore.MUICore.AddressRequest.TargetType.FIND.getNumber()) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(13, type_);
+          .computeEnumSize(27, type_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -7563,7 +9018,7 @@ public final class MUICore {
 
       private long address_ ;
       /**
-       * <code>uint64 address = 12;</code>
+       * <code>uint64 address = 26;</code>
        * @return The address.
        */
       @java.lang.Override
@@ -7571,7 +9026,7 @@ public final class MUICore {
         return address_;
       }
       /**
-       * <code>uint64 address = 12;</code>
+       * <code>uint64 address = 26;</code>
        * @param value The address to set.
        * @return This builder for chaining.
        */
@@ -7582,7 +9037,7 @@ public final class MUICore {
         return this;
       }
       /**
-       * <code>uint64 address = 12;</code>
+       * <code>uint64 address = 26;</code>
        * @return This builder for chaining.
        */
       public Builder clearAddress() {
@@ -7594,14 +9049,14 @@ public final class MUICore {
 
       private int type_ = 0;
       /**
-       * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+       * <code>.muicore.AddressRequest.TargetType type = 27;</code>
        * @return The enum numeric value on the wire for type.
        */
       @java.lang.Override public int getTypeValue() {
         return type_;
       }
       /**
-       * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+       * <code>.muicore.AddressRequest.TargetType type = 27;</code>
        * @param value The enum numeric value on the wire for type to set.
        * @return This builder for chaining.
        */
@@ -7612,7 +9067,7 @@ public final class MUICore {
         return this;
       }
       /**
-       * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+       * <code>.muicore.AddressRequest.TargetType type = 27;</code>
        * @return The type.
        */
       @java.lang.Override
@@ -7622,7 +9077,7 @@ public final class MUICore {
         return result == null ? muicore.MUICore.AddressRequest.TargetType.UNRECOGNIZED : result;
       }
       /**
-       * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+       * <code>.muicore.AddressRequest.TargetType type = 27;</code>
        * @param value The type to set.
        * @return This builder for chaining.
        */
@@ -7636,7 +9091,7 @@ public final class MUICore {
         return this;
       }
       /**
-       * <code>.muicore.AddressRequest.TargetType type = 13;</code>
+       * <code>.muicore.AddressRequest.TargetType type = 27;</code>
        * @return This builder for chaining.
        */
       public Builder clearType() {
@@ -8707,10 +10162,15 @@ public final class MUICore {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_muicore_TerminateResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_muicore_CLIArguments_descriptor;
+    internal_static_muicore_NativeArguments_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_muicore_CLIArguments_fieldAccessorTable;
+      internal_static_muicore_NativeArguments_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_muicore_EVMArguments_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_muicore_EVMArguments_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_muicore_AddressRequest_descriptor;
   private static final 
@@ -8746,28 +10206,34 @@ public final class MUICore {
       "uicore.MUIState\022*\n\017complete_states\030\010 \003(\013" +
       "2\021.muicore.MUIState\"!\n\021ManticoreInstance" +
       "\022\014\n\004uuid\030\t \001(\t\"$\n\021TerminateResponse\022\017\n\007s" +
-      "uccess\030\n \001(\010\"\252\001\n\014CLIArguments\022\024\n\014program" +
-      "_path\030\013 \001(\t\022\023\n\013binary_args\030\020 \003(\t\022\014\n\004envp" +
-      "\030\021 \003(\t\022\026\n\016symbolic_files\030\022 \003(\t\022\026\n\016concre" +
-      "te_start\030\023 \001(\t\022\022\n\nstdin_size\030\024 \001(\t\022\035\n\025ad" +
-      "ditional_mcore_args\030\025 \001(\t\"\201\001\n\016AddressReq" +
-      "uest\022\017\n\007address\030\014 \001(\004\0220\n\004type\030\r \001(\0162\".mu" +
-      "icore.AddressRequest.TargetType\",\n\nTarge" +
-      "tType\022\010\n\004FIND\020\000\022\t\n\005AVOID\020\001\022\t\n\005CLEAR\020\002\"!\n" +
-      "\016TargetResponse\022\017\n\007success\030\016 \001(\010\",\n\026Mant" +
-      "icoreRunningStatus\022\022\n\nis_running\030\017 \001(\0102\275" +
-      "\003\n\013ManticoreUI\022E\n\tTerminate\022\032.muicore.Ma" +
-      "nticoreInstance\032\032.muicore.TerminateRespo" +
-      "nse\"\000\022<\n\005Start\022\025.muicore.CLIArguments\032\032." +
-      "muicore.ManticoreInstance\"\000\022C\n\rTargetAdd" +
-      "ress\022\027.muicore.AddressRequest\032\027.muicore." +
-      "TargetResponse\"\000\022C\n\014GetStateList\022\032.muico" +
-      "re.ManticoreInstance\032\025.muicore.MUIStateL" +
-      "ist\"\000\022G\n\016GetMessageList\022\032.muicore.Mantic" +
-      "oreInstance\032\027.muicore.MUIMessageList\"\000\022V" +
-      "\n\025CheckManticoreRunning\022\032.muicore.Mantic" +
-      "oreInstance\032\037.muicore.ManticoreRunningSt" +
-      "atus\"\000b\006proto3"
+      "uccess\030\n \001(\010\"\255\001\n\017NativeArguments\022\024\n\014prog" +
+      "ram_path\030\013 \001(\t\022\023\n\013binary_args\030\020 \003(\t\022\014\n\004e" +
+      "nvp\030\021 \003(\t\022\026\n\016symbolic_files\030\022 \003(\t\022\026\n\016con" +
+      "crete_start\030\023 \001(\t\022\022\n\nstdin_size\030\024 \001(\t\022\035\n" +
+      "\025additional_mcore_args\030\025 \001(\t\"\230\001\n\014EVMArgu" +
+      "ments\022\025\n\rcontract_path\030\014 \001(\t\022\025\n\rcontract" +
+      "_name\030\r \001(\t\022\017\n\007txlimit\030\026 \001(\t\022\021\n\ttxaccoun" +
+      "t\030\027 \001(\t\022\034\n\024detectors_to_exclude\030\030 \003(\t\022\030\n" +
+      "\020additional_flags\030\031 \003(\t\"\201\001\n\016AddressReque" +
+      "st\022\017\n\007address\030\032 \001(\004\0220\n\004type\030\033 \001(\0162\".muic" +
+      "ore.AddressRequest.TargetType\",\n\nTargetT" +
+      "ype\022\010\n\004FIND\020\000\022\t\n\005AVOID\020\001\022\t\n\005CLEAR\020\002\"!\n\016T" +
+      "argetResponse\022\017\n\007success\030\016 \001(\010\",\n\026Mantic" +
+      "oreRunningStatus\022\022\n\nis_running\030\017 \001(\0102\215\004\n" +
+      "\013ManticoreUI\022E\n\013StartNative\022\030.muicore.Na" +
+      "tiveArguments\032\032.muicore.ManticoreInstanc" +
+      "e\"\000\022?\n\010StartEVM\022\025.muicore.EVMArguments\032\032" +
+      ".muicore.ManticoreInstance\"\000\022E\n\tTerminat" +
+      "e\022\032.muicore.ManticoreInstance\032\032.muicore." +
+      "TerminateResponse\"\000\022C\n\014GetStateList\022\032.mu" +
+      "icore.ManticoreInstance\032\025.muicore.MUISta" +
+      "teList\"\000\022G\n\016GetMessageList\022\032.muicore.Man" +
+      "ticoreInstance\032\027.muicore.MUIMessageList\"" +
+      "\000\022V\n\025CheckManticoreRunning\022\032.muicore.Man" +
+      "ticoreInstance\032\037.muicore.ManticoreRunnin" +
+      "gStatus\"\000\022I\n\023TargetAddressNative\022\027.muico" +
+      "re.AddressRequest\032\027.muicore.TargetRespon" +
+      "se\"\000b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -8809,26 +10275,32 @@ public final class MUICore {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_muicore_TerminateResponse_descriptor,
         new java.lang.String[] { "Success", });
-    internal_static_muicore_CLIArguments_descriptor =
+    internal_static_muicore_NativeArguments_descriptor =
       getDescriptor().getMessageTypes().get(6);
-    internal_static_muicore_CLIArguments_fieldAccessorTable = new
+    internal_static_muicore_NativeArguments_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_muicore_CLIArguments_descriptor,
+        internal_static_muicore_NativeArguments_descriptor,
         new java.lang.String[] { "ProgramPath", "BinaryArgs", "Envp", "SymbolicFiles", "ConcreteStart", "StdinSize", "AdditionalMcoreArgs", });
-    internal_static_muicore_AddressRequest_descriptor =
+    internal_static_muicore_EVMArguments_descriptor =
       getDescriptor().getMessageTypes().get(7);
+    internal_static_muicore_EVMArguments_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_muicore_EVMArguments_descriptor,
+        new java.lang.String[] { "ContractPath", "ContractName", "Txlimit", "Txaccount", "DetectorsToExclude", "AdditionalFlags", });
+    internal_static_muicore_AddressRequest_descriptor =
+      getDescriptor().getMessageTypes().get(8);
     internal_static_muicore_AddressRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_muicore_AddressRequest_descriptor,
         new java.lang.String[] { "Address", "Type", });
     internal_static_muicore_TargetResponse_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(9);
     internal_static_muicore_TargetResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_muicore_TargetResponse_descriptor,
         new java.lang.String[] { "Success", });
     internal_static_muicore_ManticoreRunningStatus_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_muicore_ManticoreRunningStatus_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_muicore_ManticoreRunningStatus_descriptor,

--- a/MUI/src/main/proto/MUICore.proto
+++ b/MUI/src/main/proto/MUICore.proto
@@ -3,12 +3,13 @@ syntax = "proto3";
 package muicore;
 
 service ManticoreUI {
+    rpc StartNative(NativeArguments) returns (ManticoreInstance) {}
+    rpc StartEVM(EVMArguments) returns (ManticoreInstance) {}
     rpc Terminate(ManticoreInstance) returns (TerminateResponse) {}
-    rpc Start(CLIArguments) returns (ManticoreInstance) {}
-    rpc TargetAddress(AddressRequest) returns (TargetResponse) {}
     rpc GetStateList(ManticoreInstance) returns (MUIStateList) {}
     rpc GetMessageList(ManticoreInstance) returns (MUIMessageList) {}
     rpc CheckManticoreRunning(ManticoreInstance) returns (ManticoreRunningStatus) {}
+    rpc TargetAddressNative(AddressRequest) returns (TargetResponse) {}
 }
 
 // LogMessage and StateList message types have "MUI" in their names to distinguish them from those in mserialize
@@ -43,7 +44,7 @@ message TerminateResponse {
     bool success = 10;
 }
 
-message CLIArguments {
+message NativeArguments {
     string program_path = 11;
     repeated string binary_args = 16;	
     repeated string envp = 17;
@@ -51,6 +52,15 @@ message CLIArguments {
     string concrete_start = 19;
     string stdin_size = 20;
     string additional_mcore_args = 21;
+}
+
+message EVMArguments {
+	string contract_path = 12;
+	string contract_name = 13;
+	string txlimit = 22;
+	string txaccount = 23;
+	repeated string detectors_to_exclude = 24;
+	repeated string additional_flags = 25;
 }
 
 message AddressRequest {
@@ -61,8 +71,8 @@ message AddressRequest {
         CLEAR = 2;
     }
 
-    uint64 address = 12;
-    TargetType type = 13;
+    uint64 address = 26;
+    TargetType type = 27;
 }
 
 message TargetResponse {

--- a/MUI/src/main/proto/MUICore.proto
+++ b/MUI/src/main/proto/MUICore.proto
@@ -57,10 +57,11 @@ message NativeArguments {
 message EVMArguments {
 	string contract_path = 12;
 	string contract_name = 13;
-	string txlimit = 22;
-	string txaccount = 23;
+	string solc_bin = 14;
+	string tx_limit = 22;
+	string tx_account = 23;
 	repeated string detectors_to_exclude = 24;
-	repeated string additional_flags = 25;
+	string additional_flags = 25;
 }
 
 message AddressRequest {
@@ -76,7 +77,7 @@ message AddressRequest {
 }
 
 message TargetResponse {
-    bool success = 14;
+    bool success = 28;
 }
 
 message ManticoreRunningStatus {

--- a/MUICore/justfile
+++ b/MUICore/justfile
@@ -3,6 +3,8 @@ generate:
 
 build: generate
   shiv -c muicore -o dist/muicore_server --reproducible --no-modify --python '/usr/bin/env python3.9' --compressed .
+  #wget https://github.com/ethereum/solc-bin/blob/gh-pages/linux-amd64/solc-linux-amd64-v0.8.12%2Bcommit.f00d7308 -O dist/solc
+  #chmod 775 dist/solc
 
 install: build
-  cp dist/muicore_server ../MUI/os/linux_x86_64/
+  cp dist/* ../MUI/os/linux_x86_64/

--- a/MUICore/justfile
+++ b/MUICore/justfile
@@ -2,6 +2,7 @@ generate:
   python3 setup.py generate
 
 build: generate
+  mkdir -p dist
   shiv -c muicore -o dist/muicore_server --reproducible --no-modify --python '/usr/bin/env python3.9' --compressed .
   wget https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-v0.8.9%2Bcommit.e5eed63a -O dist/solc
   chmod 775 dist/solc

--- a/MUICore/justfile
+++ b/MUICore/justfile
@@ -3,8 +3,8 @@ generate:
 
 build: generate
   shiv -c muicore -o dist/muicore_server --reproducible --no-modify --python '/usr/bin/env python3.9' --compressed .
-  #wget https://github.com/ethereum/solc-bin/blob/gh-pages/linux-amd64/solc-linux-amd64-v0.8.12%2Bcommit.f00d7308 -O dist/solc
+  #wget https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-v0.8.12%2Bcommit.f00d7308 -O dist/solc
   #chmod 775 dist/solc
 
 install: build
-  cp dist/* ../MUI/os/linux_x86_64/
+  cp dist/muicore_server ../MUI/os/linux_x86_64/

--- a/MUICore/justfile
+++ b/MUICore/justfile
@@ -3,8 +3,8 @@ generate:
 
 build: generate
   shiv -c muicore -o dist/muicore_server --reproducible --no-modify --python '/usr/bin/env python3.9' --compressed .
-  #wget https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-v0.8.12%2Bcommit.f00d7308 -O dist/solc
-  #chmod 775 dist/solc
+  wget https://github.com/ethereum/solc-bin/raw/gh-pages/linux-amd64/solc-linux-amd64-v0.8.9%2Bcommit.e5eed63a -O dist/solc
+  chmod 775 dist/solc
 
 install: build
-  cp dist/muicore_server ../MUI/os/linux_x86_64/
+  cp dist/* ../MUI/os/linux_x86_64/

--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -3,12 +3,13 @@ syntax = "proto3";
 package muicore;
 
 service ManticoreUI {
+    rpc StartNative(NativeArguments) returns (ManticoreInstance) {}
+    rpc StartEVM(EVMArguments) returns (ManticoreInstance) {}
     rpc Terminate(ManticoreInstance) returns (TerminateResponse) {}
-    rpc Start(CLIArguments) returns (ManticoreInstance) {}
-    rpc TargetAddress(AddressRequest) returns (TargetResponse) {}
     rpc GetStateList(ManticoreInstance) returns (MUIStateList) {}
     rpc GetMessageList(ManticoreInstance) returns (MUIMessageList) {}
     rpc CheckManticoreRunning(ManticoreInstance) returns (ManticoreRunningStatus) {}
+    rpc TargetAddressNative(AddressRequest) returns (TargetResponse) {}
 }
 
 // LogMessage and StateList message types have "MUI" in their names to distinguish them from those in mserialize
@@ -43,7 +44,7 @@ message TerminateResponse {
     bool success = 10;
 }
 
-message CLIArguments {
+message NativeArguments {
     string program_path = 11;
     repeated string binary_args = 16;	
     repeated string envp = 17;
@@ -51,6 +52,15 @@ message CLIArguments {
     string concrete_start = 19;
     string stdin_size = 20;
     string additional_mcore_args = 21;
+}
+
+message EVMArguments {
+	string contract_path = 12;
+	string contract_name = 13;
+	string txlimit = 22;
+	string txaccount = 23;
+	repeated string detectors_to_exclude = 24;
+	repeated string additional_flags = 25;
 }
 
 message AddressRequest {
@@ -61,8 +71,8 @@ message AddressRequest {
         CLEAR = 2;
     }
 
-    uint64 address = 12;
-    TargetType type = 13;
+    uint64 address = 26;
+    TargetType type = 27;
 }
 
 message TargetResponse {

--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -57,10 +57,10 @@ message NativeArguments {
 message EVMArguments {
 	string contract_path = 12;
 	string contract_name = 13;
-	string txlimit = 22;
-	string txaccount = 23;
+	string tx_limit = 22;
+	string tx_account = 23;
 	repeated string detectors_to_exclude = 24;
-	repeated string additional_flags = 25;
+	string additional_flags = 25;
 }
 
 message AddressRequest {

--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -57,6 +57,7 @@ message NativeArguments {
 message EVMArguments {
 	string contract_path = 12;
 	string contract_name = 13;
+	string solc_bin = 14;
 	string tx_limit = 22;
 	string tx_account = 23;
 	repeated string detectors_to_exclude = 24;
@@ -76,7 +77,7 @@ message AddressRequest {
 }
 
 message TargetResponse {
-    bool success = 14;
+    bool success = 28;
 }
 
 message ManticoreRunningStatus {

--- a/MUICore/muicore/MUICore_pb2.py
+++ b/MUICore/muicore/MUICore_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\x9a\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x0e \x01(\x08\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\x32\x8d\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x1c \x01(\x08\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\x32\x8d\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x62\x06proto3')
 
 
 
@@ -126,15 +126,15 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _NATIVEARGUMENTS._serialized_start=463
   _NATIVEARGUMENTS._serialized_end=636
   _EVMARGUMENTS._serialized_start=639
-  _EVMARGUMENTS._serialized_end=793
-  _ADDRESSREQUEST._serialized_start=796
-  _ADDRESSREQUEST._serialized_end=925
-  _ADDRESSREQUEST_TARGETTYPE._serialized_start=881
-  _ADDRESSREQUEST_TARGETTYPE._serialized_end=925
-  _TARGETRESPONSE._serialized_start=927
-  _TARGETRESPONSE._serialized_end=960
-  _MANTICORERUNNINGSTATUS._serialized_start=962
-  _MANTICORERUNNINGSTATUS._serialized_end=1006
-  _MANTICOREUI._serialized_start=1009
-  _MANTICOREUI._serialized_end=1534
+  _EVMARGUMENTS._serialized_end=811
+  _ADDRESSREQUEST._serialized_start=814
+  _ADDRESSREQUEST._serialized_end=943
+  _ADDRESSREQUEST_TARGETTYPE._serialized_start=899
+  _ADDRESSREQUEST_TARGETTYPE._serialized_end=943
+  _TARGETRESPONSE._serialized_start=945
+  _TARGETRESPONSE._serialized_end=978
+  _MANTICORERUNNINGSTATUS._serialized_start=980
+  _MANTICORERUNNINGSTATUS._serialized_end=1024
+  _MANTICOREUI._serialized_start=1027
+  _MANTICOREUI._serialized_end=1552
 # @@protoc_insertion_point(module_scope)

--- a/MUICore/muicore/MUICore_pb2.py
+++ b/MUICore/muicore/MUICore_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\x98\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x0f\n\x07txlimit\x18\x16 \x01(\t\x12\x11\n\ttxaccount\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x03(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x0e \x01(\x08\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\x32\x8d\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\x9a\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x0e \x01(\x08\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\x32\x8d\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x62\x06proto3')
 
 
 
@@ -126,15 +126,15 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _NATIVEARGUMENTS._serialized_start=463
   _NATIVEARGUMENTS._serialized_end=636
   _EVMARGUMENTS._serialized_start=639
-  _EVMARGUMENTS._serialized_end=791
-  _ADDRESSREQUEST._serialized_start=794
-  _ADDRESSREQUEST._serialized_end=923
-  _ADDRESSREQUEST_TARGETTYPE._serialized_start=879
-  _ADDRESSREQUEST_TARGETTYPE._serialized_end=923
-  _TARGETRESPONSE._serialized_start=925
-  _TARGETRESPONSE._serialized_end=958
-  _MANTICORERUNNINGSTATUS._serialized_start=960
-  _MANTICORERUNNINGSTATUS._serialized_end=1004
-  _MANTICOREUI._serialized_start=1007
-  _MANTICOREUI._serialized_end=1532
+  _EVMARGUMENTS._serialized_end=793
+  _ADDRESSREQUEST._serialized_start=796
+  _ADDRESSREQUEST._serialized_end=925
+  _ADDRESSREQUEST_TARGETTYPE._serialized_start=881
+  _ADDRESSREQUEST_TARGETTYPE._serialized_end=925
+  _TARGETRESPONSE._serialized_start=927
+  _TARGETRESPONSE._serialized_end=960
+  _MANTICORERUNNINGSTATUS._serialized_start=962
+  _MANTICORERUNNINGSTATUS._serialized_end=1006
+  _MANTICOREUI._serialized_start=1009
+  _MANTICOREUI._serialized_end=1534
 # @@protoc_insertion_point(module_scope)

--- a/MUICore/muicore/MUICore_pb2.py
+++ b/MUICore/muicore/MUICore_pb2.py
@@ -3,6 +3,7 @@
 # source: muicore/MUICore.proto
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -13,465 +14,22 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor.FileDescriptor(
-  name='muicore/MUICore.proto',
-  package='muicore',
-  syntax='proto3',
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08\"\xaa\x01\n\x0c\x43LIArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x0c \x01(\x04\x12\x30\n\x04type\x18\r \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x0e \x01(\x08\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\x32\xbd\x03\n\x0bManticoreUI\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12<\n\x05Start\x12\x15.muicore.CLIArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x43\n\rTargetAddress\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x62\x06proto3'
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\x98\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x0f\n\x07txlimit\x18\x16 \x01(\t\x12\x11\n\ttxaccount\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x03(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x0e \x01(\x08\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\x32\x8d\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x62\x06proto3')
 
 
 
-_ADDRESSREQUEST_TARGETTYPE = _descriptor.EnumDescriptor(
-  name='TargetType',
-  full_name='muicore.AddressRequest.TargetType',
-  filename=None,
-  file=DESCRIPTOR,
-  create_key=_descriptor._internal_create_key,
-  values=[
-    _descriptor.EnumValueDescriptor(
-      name='FIND', index=0, number=0,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='AVOID', index=1, number=1,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-    _descriptor.EnumValueDescriptor(
-      name='CLEAR', index=2, number=2,
-      serialized_options=None,
-      type=None,
-      create_key=_descriptor._internal_create_key),
-  ],
-  containing_type=None,
-  serialized_options=None,
-  serialized_start=721,
-  serialized_end=765,
-)
-_sym_db.RegisterEnumDescriptor(_ADDRESSREQUEST_TARGETTYPE)
-
-
-_MUILOGMESSAGE = _descriptor.Descriptor(
-  name='MUILogMessage',
-  full_name='muicore.MUILogMessage',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='content', full_name='muicore.MUILogMessage.content', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=34,
-  serialized_end=66,
-)
-
-
-_MUIMESSAGELIST = _descriptor.Descriptor(
-  name='MUIMessageList',
-  full_name='muicore.MUIMessageList',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='messages', full_name='muicore.MUIMessageList.messages', index=0,
-      number=2, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=68,
-  serialized_end=126,
-)
-
-
-_MUISTATE = _descriptor.Descriptor(
-  name='MUIState',
-  full_name='muicore.MUIState',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='state_id', full_name='muicore.MUIState.state_id', index=0,
-      number=3, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=128,
-  serialized_end=156,
-)
-
-
-_MUISTATELIST = _descriptor.Descriptor(
-  name='MUIStateList',
-  full_name='muicore.MUIStateList',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='active_states', full_name='muicore.MUIStateList.active_states', index=0,
-      number=4, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='waiting_states', full_name='muicore.MUIStateList.waiting_states', index=1,
-      number=5, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='forked_states', full_name='muicore.MUIStateList.forked_states', index=2,
-      number=6, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='errored_states', full_name='muicore.MUIStateList.errored_states', index=3,
-      number=7, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='complete_states', full_name='muicore.MUIStateList.complete_states', index=4,
-      number=8, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=159,
-  serialized_end=387,
-)
-
-
-_MANTICOREINSTANCE = _descriptor.Descriptor(
-  name='ManticoreInstance',
-  full_name='muicore.ManticoreInstance',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='uuid', full_name='muicore.ManticoreInstance.uuid', index=0,
-      number=9, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=389,
-  serialized_end=422,
-)
-
-
-_TERMINATERESPONSE = _descriptor.Descriptor(
-  name='TerminateResponse',
-  full_name='muicore.TerminateResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='success', full_name='muicore.TerminateResponse.success', index=0,
-      number=10, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=424,
-  serialized_end=460,
-)
-
-
-_CLIARGUMENTS = _descriptor.Descriptor(
-  name='CLIArguments',
-  full_name='muicore.CLIArguments',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='program_path', full_name='muicore.CLIArguments.program_path', index=0,
-      number=11, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='binary_args', full_name='muicore.CLIArguments.binary_args', index=1,
-      number=16, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='envp', full_name='muicore.CLIArguments.envp', index=2,
-      number=17, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='symbolic_files', full_name='muicore.CLIArguments.symbolic_files', index=3,
-      number=18, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='concrete_start', full_name='muicore.CLIArguments.concrete_start', index=4,
-      number=19, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='stdin_size', full_name='muicore.CLIArguments.stdin_size', index=5,
-      number=20, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='additional_mcore_args', full_name='muicore.CLIArguments.additional_mcore_args', index=6,
-      number=21, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=463,
-  serialized_end=633,
-)
-
-
-_ADDRESSREQUEST = _descriptor.Descriptor(
-  name='AddressRequest',
-  full_name='muicore.AddressRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='address', full_name='muicore.AddressRequest.address', index=0,
-      number=12, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='type', full_name='muicore.AddressRequest.type', index=1,
-      number=13, type=14, cpp_type=8, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-    _ADDRESSREQUEST_TARGETTYPE,
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=636,
-  serialized_end=765,
-)
-
-
-_TARGETRESPONSE = _descriptor.Descriptor(
-  name='TargetResponse',
-  full_name='muicore.TargetResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='success', full_name='muicore.TargetResponse.success', index=0,
-      number=14, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=767,
-  serialized_end=800,
-)
-
-
-_MANTICORERUNNINGSTATUS = _descriptor.Descriptor(
-  name='ManticoreRunningStatus',
-  full_name='muicore.ManticoreRunningStatus',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='is_running', full_name='muicore.ManticoreRunningStatus.is_running', index=0,
-      number=15, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=802,
-  serialized_end=846,
-)
-
-_MUIMESSAGELIST.fields_by_name['messages'].message_type = _MUILOGMESSAGE
-_MUISTATELIST.fields_by_name['active_states'].message_type = _MUISTATE
-_MUISTATELIST.fields_by_name['waiting_states'].message_type = _MUISTATE
-_MUISTATELIST.fields_by_name['forked_states'].message_type = _MUISTATE
-_MUISTATELIST.fields_by_name['errored_states'].message_type = _MUISTATE
-_MUISTATELIST.fields_by_name['complete_states'].message_type = _MUISTATE
-_ADDRESSREQUEST.fields_by_name['type'].enum_type = _ADDRESSREQUEST_TARGETTYPE
-_ADDRESSREQUEST_TARGETTYPE.containing_type = _ADDRESSREQUEST
-DESCRIPTOR.message_types_by_name['MUILogMessage'] = _MUILOGMESSAGE
-DESCRIPTOR.message_types_by_name['MUIMessageList'] = _MUIMESSAGELIST
-DESCRIPTOR.message_types_by_name['MUIState'] = _MUISTATE
-DESCRIPTOR.message_types_by_name['MUIStateList'] = _MUISTATELIST
-DESCRIPTOR.message_types_by_name['ManticoreInstance'] = _MANTICOREINSTANCE
-DESCRIPTOR.message_types_by_name['TerminateResponse'] = _TERMINATERESPONSE
-DESCRIPTOR.message_types_by_name['CLIArguments'] = _CLIARGUMENTS
-DESCRIPTOR.message_types_by_name['AddressRequest'] = _ADDRESSREQUEST
-DESCRIPTOR.message_types_by_name['TargetResponse'] = _TARGETRESPONSE
-DESCRIPTOR.message_types_by_name['ManticoreRunningStatus'] = _MANTICORERUNNINGSTATUS
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
+_MUILOGMESSAGE = DESCRIPTOR.message_types_by_name['MUILogMessage']
+_MUIMESSAGELIST = DESCRIPTOR.message_types_by_name['MUIMessageList']
+_MUISTATE = DESCRIPTOR.message_types_by_name['MUIState']
+_MUISTATELIST = DESCRIPTOR.message_types_by_name['MUIStateList']
+_MANTICOREINSTANCE = DESCRIPTOR.message_types_by_name['ManticoreInstance']
+_TERMINATERESPONSE = DESCRIPTOR.message_types_by_name['TerminateResponse']
+_NATIVEARGUMENTS = DESCRIPTOR.message_types_by_name['NativeArguments']
+_EVMARGUMENTS = DESCRIPTOR.message_types_by_name['EVMArguments']
+_ADDRESSREQUEST = DESCRIPTOR.message_types_by_name['AddressRequest']
+_TARGETRESPONSE = DESCRIPTOR.message_types_by_name['TargetResponse']
+_MANTICORERUNNINGSTATUS = DESCRIPTOR.message_types_by_name['ManticoreRunningStatus']
+_ADDRESSREQUEST_TARGETTYPE = _ADDRESSREQUEST.enum_types_by_name['TargetType']
 MUILogMessage = _reflection.GeneratedProtocolMessageType('MUILogMessage', (_message.Message,), {
   'DESCRIPTOR' : _MUILOGMESSAGE,
   '__module__' : 'muicore.MUICore_pb2'
@@ -514,12 +72,19 @@ TerminateResponse = _reflection.GeneratedProtocolMessageType('TerminateResponse'
   })
 _sym_db.RegisterMessage(TerminateResponse)
 
-CLIArguments = _reflection.GeneratedProtocolMessageType('CLIArguments', (_message.Message,), {
-  'DESCRIPTOR' : _CLIARGUMENTS,
+NativeArguments = _reflection.GeneratedProtocolMessageType('NativeArguments', (_message.Message,), {
+  'DESCRIPTOR' : _NATIVEARGUMENTS,
   '__module__' : 'muicore.MUICore_pb2'
-  # @@protoc_insertion_point(class_scope:muicore.CLIArguments)
+  # @@protoc_insertion_point(class_scope:muicore.NativeArguments)
   })
-_sym_db.RegisterMessage(CLIArguments)
+_sym_db.RegisterMessage(NativeArguments)
+
+EVMArguments = _reflection.GeneratedProtocolMessageType('EVMArguments', (_message.Message,), {
+  'DESCRIPTOR' : _EVMARGUMENTS,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.EVMArguments)
+  })
+_sym_db.RegisterMessage(EVMArguments)
 
 AddressRequest = _reflection.GeneratedProtocolMessageType('AddressRequest', (_message.Message,), {
   'DESCRIPTOR' : _ADDRESSREQUEST,
@@ -542,81 +107,34 @@ ManticoreRunningStatus = _reflection.GeneratedProtocolMessageType('ManticoreRunn
   })
 _sym_db.RegisterMessage(ManticoreRunningStatus)
 
+_MANTICOREUI = DESCRIPTOR.services_by_name['ManticoreUI']
+if _descriptor._USE_C_DESCRIPTORS == False:
 
-
-_MANTICOREUI = _descriptor.ServiceDescriptor(
-  name='ManticoreUI',
-  full_name='muicore.ManticoreUI',
-  file=DESCRIPTOR,
-  index=0,
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_start=849,
-  serialized_end=1294,
-  methods=[
-  _descriptor.MethodDescriptor(
-    name='Terminate',
-    full_name='muicore.ManticoreUI.Terminate',
-    index=0,
-    containing_service=None,
-    input_type=_MANTICOREINSTANCE,
-    output_type=_TERMINATERESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='Start',
-    full_name='muicore.ManticoreUI.Start',
-    index=1,
-    containing_service=None,
-    input_type=_CLIARGUMENTS,
-    output_type=_MANTICOREINSTANCE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='TargetAddress',
-    full_name='muicore.ManticoreUI.TargetAddress',
-    index=2,
-    containing_service=None,
-    input_type=_ADDRESSREQUEST,
-    output_type=_TARGETRESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='GetStateList',
-    full_name='muicore.ManticoreUI.GetStateList',
-    index=3,
-    containing_service=None,
-    input_type=_MANTICOREINSTANCE,
-    output_type=_MUISTATELIST,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='GetMessageList',
-    full_name='muicore.ManticoreUI.GetMessageList',
-    index=4,
-    containing_service=None,
-    input_type=_MANTICOREINSTANCE,
-    output_type=_MUIMESSAGELIST,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-  _descriptor.MethodDescriptor(
-    name='CheckManticoreRunning',
-    full_name='muicore.ManticoreUI.CheckManticoreRunning',
-    index=5,
-    containing_service=None,
-    input_type=_MANTICOREINSTANCE,
-    output_type=_MANTICORERUNNINGSTATUS,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-])
-_sym_db.RegisterServiceDescriptor(_MANTICOREUI)
-
-DESCRIPTOR.services_by_name['ManticoreUI'] = _MANTICOREUI
-
+  DESCRIPTOR._options = None
+  _MUILOGMESSAGE._serialized_start=34
+  _MUILOGMESSAGE._serialized_end=66
+  _MUIMESSAGELIST._serialized_start=68
+  _MUIMESSAGELIST._serialized_end=126
+  _MUISTATE._serialized_start=128
+  _MUISTATE._serialized_end=156
+  _MUISTATELIST._serialized_start=159
+  _MUISTATELIST._serialized_end=387
+  _MANTICOREINSTANCE._serialized_start=389
+  _MANTICOREINSTANCE._serialized_end=422
+  _TERMINATERESPONSE._serialized_start=424
+  _TERMINATERESPONSE._serialized_end=460
+  _NATIVEARGUMENTS._serialized_start=463
+  _NATIVEARGUMENTS._serialized_end=636
+  _EVMARGUMENTS._serialized_start=639
+  _EVMARGUMENTS._serialized_end=791
+  _ADDRESSREQUEST._serialized_start=794
+  _ADDRESSREQUEST._serialized_end=923
+  _ADDRESSREQUEST_TARGETTYPE._serialized_start=879
+  _ADDRESSREQUEST_TARGETTYPE._serialized_end=923
+  _TARGETRESPONSE._serialized_start=925
+  _TARGETRESPONSE._serialized_end=958
+  _MANTICORERUNNINGSTATUS._serialized_start=960
+  _MANTICORERUNNINGSTATUS._serialized_end=1004
+  _MANTICOREUI._serialized_start=1007
+  _MANTICOREUI._serialized_end=1532
 # @@protoc_insertion_point(module_scope)

--- a/MUICore/muicore/MUICore_pb2_grpc.py
+++ b/MUICore/muicore/MUICore_pb2_grpc.py
@@ -14,20 +14,20 @@ class ManticoreUIStub(object):
         Args:
             channel: A grpc.Channel.
         """
+        self.StartNative = channel.unary_unary(
+                '/muicore.ManticoreUI/StartNative',
+                request_serializer=muicore_dot_MUICore__pb2.NativeArguments.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                )
+        self.StartEVM = channel.unary_unary(
+                '/muicore.ManticoreUI/StartEVM',
+                request_serializer=muicore_dot_MUICore__pb2.EVMArguments.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                )
         self.Terminate = channel.unary_unary(
                 '/muicore.ManticoreUI/Terminate',
                 request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
                 response_deserializer=muicore_dot_MUICore__pb2.TerminateResponse.FromString,
-                )
-        self.Start = channel.unary_unary(
-                '/muicore.ManticoreUI/Start',
-                request_serializer=muicore_dot_MUICore__pb2.CLIArguments.SerializeToString,
-                response_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-                )
-        self.TargetAddress = channel.unary_unary(
-                '/muicore.ManticoreUI/TargetAddress',
-                request_serializer=muicore_dot_MUICore__pb2.AddressRequest.SerializeToString,
-                response_deserializer=muicore_dot_MUICore__pb2.TargetResponse.FromString,
                 )
         self.GetStateList = channel.unary_unary(
                 '/muicore.ManticoreUI/GetStateList',
@@ -44,24 +44,29 @@ class ManticoreUIStub(object):
                 request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
                 response_deserializer=muicore_dot_MUICore__pb2.ManticoreRunningStatus.FromString,
                 )
+        self.TargetAddressNative = channel.unary_unary(
+                '/muicore.ManticoreUI/TargetAddressNative',
+                request_serializer=muicore_dot_MUICore__pb2.AddressRequest.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.TargetResponse.FromString,
+                )
 
 
 class ManticoreUIServicer(object):
     """Missing associated documentation comment in .proto file."""
 
+    def StartNative(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def StartEVM(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
     def Terminate(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def Start(self, request, context):
-        """Missing associated documentation comment in .proto file."""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def TargetAddress(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -85,23 +90,29 @@ class ManticoreUIServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def TargetAddressNative(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_ManticoreUIServicer_to_server(servicer, server):
     rpc_method_handlers = {
+            'StartNative': grpc.unary_unary_rpc_method_handler(
+                    servicer.StartNative,
+                    request_deserializer=muicore_dot_MUICore__pb2.NativeArguments.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+            ),
+            'StartEVM': grpc.unary_unary_rpc_method_handler(
+                    servicer.StartEVM,
+                    request_deserializer=muicore_dot_MUICore__pb2.EVMArguments.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+            ),
             'Terminate': grpc.unary_unary_rpc_method_handler(
                     servicer.Terminate,
                     request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
                     response_serializer=muicore_dot_MUICore__pb2.TerminateResponse.SerializeToString,
-            ),
-            'Start': grpc.unary_unary_rpc_method_handler(
-                    servicer.Start,
-                    request_deserializer=muicore_dot_MUICore__pb2.CLIArguments.FromString,
-                    response_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
-            ),
-            'TargetAddress': grpc.unary_unary_rpc_method_handler(
-                    servicer.TargetAddress,
-                    request_deserializer=muicore_dot_MUICore__pb2.AddressRequest.FromString,
-                    response_serializer=muicore_dot_MUICore__pb2.TargetResponse.SerializeToString,
             ),
             'GetStateList': grpc.unary_unary_rpc_method_handler(
                     servicer.GetStateList,
@@ -118,6 +129,11 @@ def add_ManticoreUIServicer_to_server(servicer, server):
                     request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
                     response_serializer=muicore_dot_MUICore__pb2.ManticoreRunningStatus.SerializeToString,
             ),
+            'TargetAddressNative': grpc.unary_unary_rpc_method_handler(
+                    servicer.TargetAddressNative,
+                    request_deserializer=muicore_dot_MUICore__pb2.AddressRequest.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.TargetResponse.SerializeToString,
+            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
             'muicore.ManticoreUI', rpc_method_handlers)
@@ -127,6 +143,40 @@ def add_ManticoreUIServicer_to_server(servicer, server):
  # This class is part of an EXPERIMENTAL API.
 class ManticoreUI(object):
     """Missing associated documentation comment in .proto file."""
+
+    @staticmethod
+    def StartNative(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/StartNative',
+            muicore_dot_MUICore__pb2.NativeArguments.SerializeToString,
+            muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def StartEVM(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/StartEVM',
+            muicore_dot_MUICore__pb2.EVMArguments.SerializeToString,
+            muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
     def Terminate(request,
@@ -142,40 +192,6 @@ class ManticoreUI(object):
         return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/Terminate',
             muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
             muicore_dot_MUICore__pb2.TerminateResponse.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
-
-    @staticmethod
-    def Start(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/Start',
-            muicore_dot_MUICore__pb2.CLIArguments.SerializeToString,
-            muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-            options, channel_credentials,
-            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
-
-    @staticmethod
-    def TargetAddress(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/TargetAddress',
-            muicore_dot_MUICore__pb2.AddressRequest.SerializeToString,
-            muicore_dot_MUICore__pb2.TargetResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -227,5 +243,22 @@ class ManticoreUI(object):
         return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/CheckManticoreRunning',
             muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
             muicore_dot_MUICore__pb2.ManticoreRunningStatus.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def TargetAddressNative(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/TargetAddressNative',
+            muicore_dot_MUICore__pb2.AddressRequest.SerializeToString,
+            muicore_dot_MUICore__pb2.TargetResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/MUICore/muicore/evm_utils.py
+++ b/MUICore/muicore/evm_utils.py
@@ -50,19 +50,23 @@ def get_detectors_classes():
         # DetectRaceCondition
     ]
 
+
 def parse_detectors(detectors_to_exclude: List[str]) -> List[Type[Detector]]:
     all_detector_classes = get_detectors_classes()
-    all_detector_args = map(lambda x:x.ARGUMENT, all_detector_classes)
+    all_detector_args = map(lambda x: x.ARGUMENT, all_detector_classes)
     for d in detectors_to_exclude:
         if d not in all_detector_args:
             raise Exception(
                 f"{d} is not a detector name, must be one of {list(all_detector_args)}. See also `--list-detectors`."
             )
-    
+
     return [d for d in all_detector_classes if d.ARGUMENT not in detectors_to_exclude]
-    
-def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str, m: ManticoreEVM) -> argparse.Namespace:
-    
+
+
+def setup_detectors_flags(
+    detectors_to_exclude: List[str], additional_flags: str, m: ManticoreEVM
+) -> argparse.Namespace:
+
     parser = argparse.ArgumentParser(
         description="Symbolic execution tool",
         prog="manticore",
@@ -76,7 +80,7 @@ def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str
         default=False,
         description="Explore states in which only the balance was changed",
     )
-    
+
     consts.add(
         "skip_reverts",
         default=False,
@@ -86,19 +90,25 @@ def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str
     # Add crytic compile arguments
     # See https://github.com/crytic/crytic-compile/wiki/Configuration
     cryticparser.init(parser)
-    
+
     eth_flags = parser.add_argument_group("Ethereum flags")
-    
+
     eth_flags.add_argument(
-        "--verbose-trace", action="store_true", help="Dump an extra verbose trace for each state"
+        "--verbose-trace",
+        action="store_true",
+        help="Dump an extra verbose trace for each state",
     )
 
     eth_flags.add_argument(
-        "--txnocoverage", action="store_true", help="Do not use coverage as stopping criteria"
+        "--txnocoverage",
+        action="store_true",
+        help="Do not use coverage as stopping criteria",
     )
 
     eth_flags.add_argument(
-        "--txnoether", action="store_true", help="Do not attempt to send ether to contract"
+        "--txnoether",
+        action="store_true",
+        help="Do not attempt to send ether to contract",
     )
 
     eth_flags.add_argument(
@@ -106,7 +116,7 @@ def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str
         action="store_true",
         help="Constrain human transactions to avoid exceptions in the contract function dispatcher",
     )
-    
+
     eth_flags.add_argument(
         "--avoid-constant",
         action="store_true",
@@ -137,10 +147,10 @@ def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str
         help="Configure Manticore for more exhaustive exploration. Evaluate gas, generate testcases for dead states, "
         "explore constant functions, and run a small suite of detectors.",
     )
-    
+
     config_flags = parser.add_argument_group("Constants")
     config.add_config_vars_to_argparse(config_flags)
-    
+
     args = parser.parse_args(shlex.split(additional_flags))
     config.process_config_values(parser, args)
 
@@ -151,7 +161,7 @@ def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str
         consts_evm = config.get_group("evm")
         consts_evm.oog = "ignore"
         consts.skip_reverts = True
-    
+
     if consts.skip_reverts:
         m.register_plugin(SkipRevertBasicBlocks())
 
@@ -163,10 +173,10 @@ def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str
 
     if args.limit_loops:
         m.register_plugin(LoopDepthLimiter())
-        
+
     for detector in parse_detectors(detectors_to_exclude):
         m.register_plugin(detector())
-    
+
     if consts.profile:
         profiler = Profiler()
         m.register_plugin(profiler)
@@ -181,7 +191,4 @@ def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str
     if m.plugins:
         print(f'Registered plugins: {", ".join(d.name for d in m.plugins.values())}')
 
-    
     return args
-
-    

--- a/MUICore/muicore/evm_utils.py
+++ b/MUICore/muicore/evm_utils.py
@@ -32,7 +32,7 @@ from manticore.ethereum.plugins import (
 from crytic_compile import cryticparser
 
 
-def get_detectors_classes():
+def get_detectors_classes() -> List[Type[Detector]]:
     return [
         DetectInvalid,
         DetectIntegerOverflow,
@@ -52,6 +52,7 @@ def get_detectors_classes():
 
 
 def parse_detectors(detectors_to_exclude: List[str]) -> List[Type[Detector]]:
+    """returns a list of detectors that should be used"""
     all_detector_classes = get_detectors_classes()
     all_detector_args = map(lambda x: x.ARGUMENT, all_detector_classes)
     for d in detectors_to_exclude:
@@ -66,6 +67,7 @@ def parse_detectors(detectors_to_exclude: List[str]) -> List[Type[Detector]]:
 def setup_detectors_flags(
     detectors_to_exclude: List[str], additional_flags: str, m: ManticoreEVM
 ) -> argparse.Namespace:
+    """parse and apply additional arguments for manticore EVM execution, CLI-style"""
 
     parser = argparse.ArgumentParser(
         description="Symbolic execution tool",

--- a/MUICore/muicore/evm_utils.py
+++ b/MUICore/muicore/evm_utils.py
@@ -1,0 +1,167 @@
+import argparse
+from typing import List, Type
+
+from manticore.ethereum import ManticoreEVM
+
+from manticore.ethereum import (
+    Detector,
+    DetectInvalid,
+    DetectIntegerOverflow,
+    DetectUninitializedStorage,
+    DetectUninitializedMemory,
+    DetectReentrancySimple,
+    DetectReentrancyAdvanced,
+    DetectUnusedRetVal,
+    DetectSuicidal,
+    DetectDelegatecall,
+    DetectExternalCallAndLeak,
+    DetectEnvInstruction,
+    DetectManipulableBalance,
+)
+
+from manticore.ethereum.plugins import (
+    FilterFunctions,
+    LoopDepthLimiter,
+    VerboseTrace,
+    KeepOnlyIfStorageChanges,
+    SkipRevertBasicBlocks,
+)
+
+from crytic_compile import cryticparser
+
+
+def get_detectors_classes():
+    return [
+        DetectInvalid,
+        DetectIntegerOverflow,
+        DetectUninitializedStorage,
+        DetectUninitializedMemory,
+        DetectReentrancySimple,
+        DetectReentrancyAdvanced,
+        DetectUnusedRetVal,
+        DetectSuicidal,
+        DetectDelegatecall,
+        DetectExternalCallAndLeak,
+        DetectEnvInstruction,
+        DetectManipulableBalance,
+        # The RaceCondition detector has been disabled for now as it seems to collide with IntegerOverflow detector
+        # DetectRaceCondition
+    ]
+
+def parse_detectors(detectors_to_exclude: List[str]) -> List[Type[Detector]]:
+    all_detector_classes = get_detectors_classes()
+    all_detector_args = map(lambda x:x.ARGUMENT, all_detector_classes)
+    for d in detectors_to_exclude:
+        if d not in all_detector_args:
+            raise Exception(
+                f"{d} is not a detector name, must be one of {list(all_detector_args)}. See also `--list-detectors`."
+            )
+    
+    return [d for d in all_detector_classes if d.ARGUMENT not in detectors_to_exclude]
+    
+def setup_detectors_flags(detectors_to_exclude: List[str], additional_flags: str, m: ManticoreEVM) -> argparse.Namespace:
+    
+    parser = argparse.ArgumentParser(
+        description="Symbolic execution tool",
+        prog="manticore",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Add crytic compile arguments
+    # See https://github.com/crytic/crytic-compile/wiki/Configuration
+    cryticparser.init(parser)
+    
+    eth_flags = parser.add_argument_group("Ethereum flags")
+    
+    eth_flags.add_argument(
+        "--verbose-trace", action="store_true", help="Dump an extra verbose trace for each state"
+    )
+
+    eth_flags.add_argument(
+        "--txnocoverage", action="store_true", help="Do not use coverage as stopping criteria"
+    )
+
+    eth_flags.add_argument(
+        "--txnoether", action="store_true", help="Do not attempt to send ether to contract"
+    )
+
+    eth_flags.add_argument(
+        "--txpreconstrain",
+        action="store_true",
+        help="Constrain human transactions to avoid exceptions in the contract function dispatcher",
+    )
+    
+    eth_flags.add_argument(
+        "--avoid-constant",
+        action="store_true",
+        help="Avoid exploring constant functions for human transactions",
+    )
+
+    eth_flags.add_argument(
+        "--limit-loops",
+        action="store_true",
+        help="Limit loops depth",
+    )
+
+    eth_flags.add_argument(
+        "--no-testcases",
+        action="store_true",
+        help="Do not generate testcases for discovered states when analysis finishes",
+    )
+
+    eth_flags.add_argument(
+        "--only-alive-testcases",
+        action="store_true",
+        help="Do not generate testcases for invalid/throwing states when analysis finishes",
+    )
+
+    eth_flags.add_argument(
+        "--thorough-mode",
+        action="store_true",
+        help="Configure Manticore for more exhaustive exploration. Evaluate gas, generate testcases for dead states, "
+        "explore constant functions, and run a small suite of detectors.",
+    )
+    
+    args = parser.parse_args(shlex.split(additional_flags))
+    
+    if not args.thorough_mode:
+        args.avoid_constant = True
+        args.exclude_all = True
+        args.only_alive_testcases = True
+        consts_evm = config.get_group("evm")
+        consts_evm.oog = "ignore"
+        consts.skip_reverts = True
+    
+    if consts.skip_reverts:
+        m.register_plugin(SkipRevertBasicBlocks())
+
+    if consts.explore_balance:
+        m.register_plugin(KeepOnlyIfStorageChanges())
+
+    if args.verbose_trace:
+        m.register_plugin(VerboseTrace())
+
+    if args.limit_loops:
+        m.register_plugin(LoopDepthLimiter())
+        
+    for detector in parse_detectors(detectors_to_exclude):
+        m.register_plugin(detector())
+    
+    if consts.profile:
+        profiler = Profiler()
+        m.register_plugin(profiler)
+
+    if args.avoid_constant:
+        # avoid all human level tx that has no effect on the storage
+        filter_nohuman_constants = FilterFunctions(
+            regexp=r".*", depth="human", mutability="constant", include=False
+        )
+        m.register_plugin(filter_nohuman_constants)
+
+    if m.plugins:
+        logger.info(f'Registered plugins: {", ".join(d.name for d in m.plugins.values())}')
+
+    
+    return args
+
+    

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -128,10 +128,10 @@ class MUIServicer(ManticoreUIServicer):
                     contract_name = evm_arguments.contract_name,
                     tx_limit=-1 if not evm_arguments.tx_limit else evm_arguments.tx_limit,
                     tx_use_coverage=True if args.txnocoverage == None else args.txnocoverage,
-                    tx_send_ether=True if args.txsendether == None else args.txsendether,
+                    tx_send_ether=True if args.txnoether == None else args.txnoether,
                     tx_account="attacker" if not evm_arguments.tx_account else evm_arguments.tx_account,
                     tx_preconstrain=False if args.txpreconstrain == None else args.txpreconstrain,
-                    compile_args={"solc_solcs_bin": "solc"},
+                    compile_args={"solc_solcs_bin": evm_arguments.solc_bin},
                 )
                 
                 if not options["no_testcases"]:
@@ -230,7 +230,7 @@ class MUIServicer(ManticoreUIServicer):
         Currently, implementation is based on TUI."""
         if mcore_instance.uuid not in self.manticore_instances:
             return MUIMessageList(
-                messages=[LogMessage(content="Manticore instance not found!")]
+                messages=[MUILogMessage(content="Manticore instance not found!")]
             )
         m = self.manticore_instances[mcore_instance.uuid][0]
         q = m._log_queue

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -21,7 +21,7 @@ from manticore.utils.enums import StateStatus, StateLists
 import uuid
 from manticore.core.state_pb2 import MessageList
 
-from .utils import parse_additional_arguments
+from .utils import parse_native_arguments
 
 
 class MUIServicer(ManticoreUIServicer):
@@ -34,33 +34,33 @@ class MUIServicer(ManticoreUIServicer):
         self.avoid = set()
         self.find = set()
 
-    def Start(
-        self, cli_arguments: CLIArguments, context: _Context
+    def StartNative(
+        self, native_arguments: NativeArguments, context: _Context
     ) -> ManticoreInstance:
         """Starts a singular Manticore instance with the given CLI Arguments"""
         id = uuid.uuid4().hex
         try:
 
-            parsed = parse_additional_arguments(cli_arguments.additional_mcore_args)
+            parsed = parse_native_arguments(native_arguments.additional_mcore_args)
             m = Manticore.linux(
-                cli_arguments.program_path,
+                native_arguments.program_path,
                 argv=None
-                if not cli_arguments.binary_args
-                else list(cli_arguments.binary_args),
+                if not native_arguments.binary_args
+                else list(native_arguments.binary_args),
                 envp=None
-                if not cli_arguments.envp
+                if not native_arguments.envp
                 else {
-                    key: val for key, val in [e.split("=") for e in cli_arguments.envp]
+                    key: val for key, val in [e.split("=") for e in native_arguments.envp]
                 },
                 symbolic_files=None
-                if not cli_arguments.symbolic_files
-                else list(cli_arguments.symbolic_files),
+                if not native_arguments.symbolic_files
+                else list(native_arguments.symbolic_files),
                 concrete_start=""
-                if not cli_arguments.concrete_start
-                else cli_arguments.concrete_start,
+                if not native_arguments.concrete_start
+                else native_arguments.concrete_start,
                 stdin_size=265
-                if not cli_arguments.stdin_size
-                else int(cli_arguments.stdin_size),
+                if not native_arguments.stdin_size
+                else int(native_arguments.stdin_size),
                 workspace_url=parsed.workspace,
                 introspection_plugin_type=MUIIntrospectionPlugin,
             )
@@ -121,7 +121,7 @@ class MUIServicer(ManticoreUIServicer):
         m.kill()
         return TerminateResponse(success=True)
 
-    def TargetAddress(
+    def TargetAddressNative(
         self, address_request: AddressRequest, context: _Context
     ) -> TargetResponse:
         """Sets addresses in the binary to find/avoid, or clears address status.

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -41,7 +41,7 @@ class MUIServicer(ManticoreUIServicer):
     def StartNative(
         self, native_arguments: NativeArguments, context: _Context
     ) -> ManticoreInstance:
-        """Starts a singular Manticore instance with the given CLI Arguments to analyze a native binary"""
+        """Starts a singular Manticore instance to analyze a native binary"""
         id = uuid.uuid4().hex
         try:
 
@@ -115,6 +115,7 @@ class MUIServicer(ManticoreUIServicer):
     def StartEVM(
         self, evm_arguments: EVMArguments, context: _Context
     ) -> ManticoreInstance:
+        """Starts a singular Manticore instance to analyze a solidity contract"""
         id = uuid.uuid4().hex
         try:
             m = ManticoreEVM()
@@ -122,7 +123,7 @@ class MUIServicer(ManticoreUIServicer):
             args = setup_detectors_flags(
                 evm_arguments.detectors_to_exclude, evm_arguments.additional_flags, m
             )
-            
+
             print(Path.cwd())
 
             def manticore_evm_runner(m: ManticoreEVM, args: argparse.Namespace):

--- a/MUICore/muicore/native_utils.py
+++ b/MUICore/muicore/native_utils.py
@@ -3,7 +3,6 @@ import pkg_resources
 import shlex
 
 from manticore.utils import config
-from crytic_compile import cryticparser
 from manticore.utils.log import set_verbosity
 
 
@@ -19,10 +18,6 @@ def parse_native_arguments(additional_args: str) -> argparse.Namespace:
         prog="manticore",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-
-    # Add crytic compile arguments
-    # See https://github.com/crytic/crytic-compile/wiki/Configuration
-    cryticparser.init(parser)
 
     parser.add_argument("--context", type=str, default=None, help=argparse.SUPPRESS)
     parser.add_argument(
@@ -108,106 +103,6 @@ def parse_native_arguments(additional_args: str) -> argparse.Namespace:
         help="Treat all writable memory as symbolic",
     )
 
-    eth_flags = parser.add_argument_group("Ethereum flags")
-    eth_flags.add_argument(
-        "--verbose-trace",
-        action="store_true",
-        help="Dump an extra verbose trace for each state",
-    )
-    eth_flags.add_argument(
-        "--txlimit",
-        type=positive,
-        help="Maximum number of symbolic transactions to run (positive integer)",
-    )
-
-    eth_flags.add_argument(
-        "--txnocoverage",
-        action="store_true",
-        help="Do not use coverage as stopping criteria",
-    )
-
-    eth_flags.add_argument(
-        "--txnoether",
-        action="store_true",
-        help="Do not attempt to send ether to contract",
-    )
-
-    eth_flags.add_argument(
-        "--txaccount",
-        type=str,
-        default="attacker",
-        help='Account used as caller in the symbolic transactions, either "attacker" or '
-        '"owner" or "combo1" (uses both)',
-    )
-
-    eth_flags.add_argument(
-        "--txpreconstrain",
-        action="store_true",
-        help="Constrain human transactions to avoid exceptions in the contract function dispatcher",
-    )
-
-    eth_flags.add_argument(
-        "--contract",
-        type=str,
-        help="Contract name to analyze in case of multiple contracts",
-    )
-
-    eth_detectors = parser.add_argument_group("Ethereum detectors")
-
-    eth_detectors.add_argument(
-        "--list-detectors",
-        help="List available detectors",
-        action=ListEthereumDetectors,
-        nargs=0,
-        default=False,
-    )
-
-    eth_detectors.add_argument(
-        "--exclude",
-        help="Comma-separated list of detectors that should be excluded",
-        action="store",
-        dest="detectors_to_exclude",
-        default="",
-    )
-
-    eth_detectors.add_argument(
-        "--exclude-all",
-        help="Excludes all detectors",
-        action="store_true",
-        default=False,
-    )
-
-    eth_flags.add_argument(
-        "--avoid-constant",
-        action="store_true",
-        help="Avoid exploring constant functions for human transactions",
-    )
-
-    eth_flags.add_argument(
-        "--limit-loops",
-        action="store_true",
-        help="Limit loops depth",
-    )
-
-    eth_flags.add_argument(
-        "--no-testcases",
-        action="store_true",
-        help="Do not generate testcases for discovered states when analysis finishes",
-    )
-
-    eth_flags.add_argument(
-        "--only-alive-testcases",
-        action="store_true",
-        help="Do not generate testcases for invalid/throwing states when analysis finishes",
-    )
-
-    eth_flags.add_argument(
-        "--thorough-mode",
-        action="store_true",
-        help="Configure Manticore for more exhaustive exploration. Evaluate gas, generate testcases for dead states, "
-        "explore constant functions, and run a small suite of detectors.",
-    )
-
     config_flags = parser.add_argument_group("Constants")
     config.add_config_vars_to_argparse(config_flags)
 
@@ -223,11 +118,3 @@ def parse_native_arguments(additional_args: str) -> argparse.Namespace:
 
     return parsed
 
-
-class ListEthereumDetectors(argparse.Action):
-    def __call__(self, parser, *args, **kwargs):
-        from manticore.ethereum.cli import get_detectors_classes
-        from manticore.utils.command_line import output_detectors
-
-        output_detectors(get_detectors_classes())
-        parser.exit()

--- a/MUICore/muicore/native_utils.py
+++ b/MUICore/muicore/native_utils.py
@@ -7,6 +7,8 @@ from manticore.utils.log import set_verbosity
 
 
 def parse_native_arguments(additional_args: str) -> argparse.Namespace:
+    """parse additional arguments for manticore native execution, CLI-style"""
+
     def positive(value):
         ivalue = int(value)
         if ivalue <= 0:

--- a/MUICore/muicore/native_utils.py
+++ b/MUICore/muicore/native_utils.py
@@ -117,4 +117,3 @@ def parse_native_arguments(additional_args: str) -> argparse.Namespace:
     set_verbosity(parsed.v)
 
     return parsed
-

--- a/MUICore/muicore/utils.py
+++ b/MUICore/muicore/utils.py
@@ -7,7 +7,7 @@ from crytic_compile import cryticparser
 from manticore.utils.log import set_verbosity
 
 
-def parse_additional_arguments(additional_args: str) -> argparse.Namespace:
+def parse_native_arguments(additional_args: str) -> argparse.Namespace:
     def positive(value):
         ivalue = int(value)
         if ivalue <= 0:

--- a/MUICore/setup.py
+++ b/MUICore/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires=[
         "manticore @ git+https://github.com/trailofbits/manticore.git@chess",
         "grpcio",
+        "crytic-compile==0.2.1",
     ]
     + native_deps,
     extras_require = {


### PR DESCRIPTION
Current implementation mirrors that of the Binja plugin. `solc` binary is included when running `just install`, must be <= 0.8.9 since manticore uses the `--combined-json compact-format` arg removed in  https://github.com/ethereum/solidity/commit/d10e668f4f89878983fcaa46e7b88462ffa4380c

this is required since we're using the chess branch for now which doesn't currently support crytic-compile 0.2.2 