### PR TITLE
Add instance-differentiated logging to MUI Core

### DIFF
--- a/MUI/src/main/java/mui/ManticoreRunner.java
+++ b/MUI/src/main/java/mui/ManticoreRunner.java
@@ -154,7 +154,7 @@ public class ManticoreRunner {
 				@Override
 				public void onNext(MUIMessageList messageList) {
 					for (MUILogMessage msg : messageList.getMessagesList()) {
-						logText.append(msg.getContent());
+						logText.append(msg.getContent() + System.lineSeparator());
 					}
 				}
 			};

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -3,8 +3,6 @@ from threading import Thread
 import argparse
 from pathlib import Path
 import logging
-import sys
-import collections
 
 import grpc
 from grpc._server import _Context
@@ -21,11 +19,9 @@ from manticore.core.plugin import (
     Tracer,
     RecordSymbolicBranches,
 )
-import manticore.utils.log
 from manticore.core.worker import WorkerThread, WorkerProcess
 from manticore.utils.log import CallbackStream, ManticoreContextFilter
 from manticore.utils.enums import StateStatus, StateLists
-
 from manticore.utils.helpers import deque
 
 import uuid

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -37,6 +37,8 @@ class ManticoreWrapper:
         self.uuid = uuid.uuid4().hex
         self.manticore_object = mcore_object
         self.thread = mthread
+        # mimics Manticore repository, reasoning for the queue size difference is provided in Manticore:
+        # https://github.com/trailofbits/manticore/blob/5a258f499098394c0af25e2e3f00b1b603c2334d/manticore/core/manticore.py#L133-L135
         self.log_queue = (
             mcore_object._manager.Queue(15000)
             if mcore_object._worker_type == WorkerProcess
@@ -48,6 +50,8 @@ class ManticoreWrapper:
         try:
             q.append(msg)
         except AttributeError:
+            # mimics Manticore repository, reasoning for using append and catching an AttributeError is provided in Manticore:
+            # https://github.com/trailofbits/manticore/blob/5a258f499098394c0af25e2e3f00b1b603c2334d/manticore/core/worker.py#L297-L303
             if q.full():
                 q.get()
             q.put(msg)

--- a/MUICore/tests/test_ethereum.py
+++ b/MUICore/tests/test_ethereum.py
@@ -21,10 +21,10 @@ class MUICoreEVMTest(unittest.TestCase):
         self.solc_path = str(self.dirname / Path("solc"))
 
     def tearDown(self):
-        for m, mthread in self.servicer.manticore_instances.values():
-            m.kill()
+        for mwrapper in self.servicer.manticore_instances.values():
+            mwrapper.manticore_object.kill()
             stime = time.time()
-            while m.is_running():
+            while mwrapper.manticore_object.is_running():
                 if (time.time() - stime) > 10:
                     time.sleep(1)
 
@@ -96,7 +96,7 @@ class MUICoreEVMTest(unittest.TestCase):
 
         self.assertTrue(mcore_instance.uuid in self.servicer.manticore_instances)
 
-        mcore = self.servicer.manticore_instances[mcore_instance.uuid][0]
+        mcore = self.servicer.manticore_instances[mcore_instance.uuid].manticore_object
         self.assertTrue(Path(mcore.workspace).is_dir())
 
     def test_terminate_running_manticore(self):
@@ -104,10 +104,10 @@ class MUICoreEVMTest(unittest.TestCase):
             EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
             None,
         )
-        m, mthread = self.servicer.manticore_instances[mcore_instance.uuid]
+        mwrapper = self.servicer.manticore_instances[mcore_instance.uuid]
 
         stime = time.time()
-        while not m.is_running():
+        while not mwrapper.manticore_object.is_running():
             if (time.time() - stime) > 5:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to start running before timeout"
@@ -116,10 +116,10 @@ class MUICoreEVMTest(unittest.TestCase):
 
         t_status = self.servicer.Terminate(mcore_instance, None)
         self.assertTrue(t_status.success)
-        self.assertTrue(m.is_killed())
+        self.assertTrue(mwrapper.manticore_object.is_killed())
 
         stime = time.time()
-        while m.is_running():
+        while mwrapper.manticore_object.is_running():
             if (time.time() - stime) > 10:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
@@ -131,10 +131,10 @@ class MUICoreEVMTest(unittest.TestCase):
             EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
             None,
         )
-        m, mthread = self.servicer.manticore_instances[mcore_instance.uuid]
-        m.kill()
+        mwrapper = self.servicer.manticore_instances[mcore_instance.uuid]
+        mwrapper.manticore_object.kill()
         stime = time.time()
-        while m.is_running():
+        while mwrapper.manticore_object.is_running():
             if (time.time() - stime) > 10:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
@@ -154,13 +154,13 @@ class MUICoreEVMTest(unittest.TestCase):
             EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
             None,
         )
-        m, mthread = self.servicer.manticore_instances[mcore_instance.uuid]
+        mwrapper = self.servicer.manticore_instances[mcore_instance.uuid]
 
         stime = time.time()
-        while m._log_queue.empty() and time.time() - stime < 5:
+        while mwrapper.manticore_object._log_queue.empty() and time.time() - stime < 5:
             time.sleep(1)
-            if not m._log_queue.empty():
-                deque_messages = list(m._log_queue)
+            if not mwrapper.manticore_object._log_queue.empty():
+                deque_messages = list(mwrapper.manticore_object._log_queue)
                 messages = self.servicer.GetMessageList(mcore_instance, None).messages
                 for i in range(len(messages)):
                     self.assertEqual(messages[i].content, deque_messages[i])
@@ -171,11 +171,11 @@ class MUICoreEVMTest(unittest.TestCase):
             EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
             None,
         )
-        m, mthread = self.servicer.manticore_instances[mcore_instance.uuid]
+        mwrapper = self.servicer.manticore_instances[mcore_instance.uuid]
 
-        m.kill()
+        mwrapper.manticore_object.kill()
         stime = time.time()
-        while m.is_running():
+        while mwrapper.manticore_object.is_running():
             if (time.time() - stime) > 10:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
@@ -183,10 +183,10 @@ class MUICoreEVMTest(unittest.TestCase):
                 time.sleep(1)
 
         stime = time.time()
-        while m._log_queue.empty() and time.time() - stime < 5:
+        while mwrapper.manticore_object._log_queue.empty() and time.time() - stime < 5:
             time.sleep(1)
-            if not m._log_queue.empty():
-                deque_messages = list(m._log_queue)
+            if not mwrapper.manticore_object._log_queue.empty():
+                deque_messages = list(mwrapper.manticore_object._log_queue)
                 messages = self.servicer.GetMessageList(mcore_instance, None).messages
                 for i in range(len(messages)):
                     self.assertEqual(messages[i].content, deque_messages[i])
@@ -206,7 +206,7 @@ class MUICoreEVMTest(unittest.TestCase):
             EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
             None,
         )
-        m, mthread = self.servicer.manticore_instances[mcore_instance.uuid]
+        mwrapper = self.servicer.manticore_instances[mcore_instance.uuid]
 
         for i in range(5):
             time.sleep(1)
@@ -221,7 +221,7 @@ class MUICoreEVMTest(unittest.TestCase):
                     + list(state_list.complete_states),
                 )
             )
-            state_ids = m.introspect().keys()
+            state_ids = mwrapper.manticore_object.introspect().keys()
 
             for sid in state_ids:
                 self.assertIn(sid, all_states)
@@ -231,11 +231,11 @@ class MUICoreEVMTest(unittest.TestCase):
             EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
             None,
         )
-        m, mthread = self.servicer.manticore_instances[mcore_instance.uuid]
+        mwrapper = self.servicer.manticore_instances[mcore_instance.uuid]
 
-        m.kill()
+        mwrapper.manticore_object.kill()
         stime = time.time()
-        while m.is_running():
+        while mwrapper.manticore_object.is_running():
             if (time.time() - stime) > 10:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
@@ -256,7 +256,7 @@ class MUICoreEVMTest(unittest.TestCase):
                     + list(state_list.complete_states),
                 )
             )
-            state_ids = m.introspect().keys()
+            state_ids = mwrapper.manticore_object.introspect().keys()
 
             for sid in state_ids:
                 self.assertIn(sid, all_states)
@@ -277,10 +277,10 @@ class MUICoreEVMTest(unittest.TestCase):
             EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
             None,
         )
-        m, mthread = self.servicer.manticore_instances[mcore_instance.uuid]
+        mwrapper = self.servicer.manticore_instances[mcore_instance.uuid]
 
         stime = time.time()
-        while not m.is_running():
+        while not mwrapper.manticore_object.is_running():
             if (time.time() - stime) > 10:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to start running before timeout"
@@ -291,10 +291,10 @@ class MUICoreEVMTest(unittest.TestCase):
             self.servicer.CheckManticoreRunning(mcore_instance, None).is_running
         )
 
-        m.kill()
+        mwrapper.manticore_object.kill()
 
         stime = time.time()
-        while m.is_running():
+        while mwrapper.manticore_object.is_running():
             if (time.time() - stime) > 10:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"


### PR DESCRIPTION
MUI-Core, and by extension MUI-Ghidra, now supports logging differentiated by each Manticore instance!

No longer uses the multiprocessing approach mentioned over Slack because grpc_server doesn't play nice with multiprocessing (specifically the `fork` instruction), and implementing the suggested workaround for this project involves spawning multiple grpc_server processes and the server receiving the manticore instance of choice before routing it to the appropriate grpc server, which I think somewhat defeats the point of using grpc...

I realised that with original multithreading approach, I could just access the `_workers` and `_daemon_threads` of each Manticore instance to get the "child" threads! Therefore, whenever a thread fires off a log record, I would search through the workers/daemonthreads of the manticore instances to figure out which manticore instance it belonged to! (this was memoised by renaming the thread so you only ever have to do this "search" once per thread that fires off any log)

this PR also introduces a ManticoreWrapper class instead of the old hacky tuple that used to store the manticore object and manticore thread