### PR TITLE
Log auto-scrolls by default with toggle

### DIFF
--- a/MUI/src/main/java/mui/MUILogContentComponent.java
+++ b/MUI/src/main/java/mui/MUILogContentComponent.java
@@ -71,9 +71,11 @@ public class MUILogContentComponent extends JPanel {
 				}
 
 			});
+		stopButton.setToolTipText("Terminate Execution");
 
 		scrollLockButton.setEnabled(true);
 		scrollLockButton.setIcon(ResourceManager.loadImage("images/lock.png"));
+		scrollLockButton.setToolTipText("Toggle Auto-Scroll Lock");
 
 		logToolBar.add(Box.createGlue()); // shifts buttons to the right
 		logToolBar.add(stopButton);

--- a/MUI/src/main/java/mui/MUILogContentComponent.java
+++ b/MUI/src/main/java/mui/MUILogContentComponent.java
@@ -7,6 +7,7 @@ import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.ScrollPaneConstants;
 import resources.ResourceManager;
@@ -20,6 +21,7 @@ public class MUILogContentComponent extends JPanel {
 
 	public JTextArea logArea;
 	public JButton stopButton;
+	public JToggleButton scrollLockButton;
 
 	public MUILogContentComponent(ManticoreRunner mcore) {
 
@@ -30,6 +32,7 @@ public class MUILogContentComponent extends JPanel {
 
 		logArea = new JTextArea();
 		stopButton = new JButton();
+		scrollLockButton = new JToggleButton();
 
 		buildLogArea();
 		buildToolBar();
@@ -68,8 +71,13 @@ public class MUILogContentComponent extends JPanel {
 				}
 
 			});
+
+		scrollLockButton.setEnabled(true);
+		scrollLockButton.setIcon(ResourceManager.loadImage("images/lock.png"));
+
 		logToolBar.add(Box.createGlue()); // shifts buttons to the right
 		logToolBar.add(stopButton);
+		logToolBar.add(scrollLockButton);
 
 		add(logToolBar, BorderLayout.PAGE_START);
 	}

--- a/MUI/src/main/java/mui/ManticoreRunner.java
+++ b/MUI/src/main/java/mui/ManticoreRunner.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JTextArea;
+import javax.swing.JToggleButton;
 import javax.swing.tree.TreePath;
 
 /**
@@ -32,6 +33,7 @@ public class ManticoreRunner {
 
 	private JTextArea logText;
 	private JButton stopBtn;
+	private JToggleButton scrollLockBtn;
 
 	private List<MUIState> activeStates;
 	private List<MUIState> waitingStates;
@@ -49,6 +51,7 @@ public class ManticoreRunner {
 
 		logText = new JTextArea();
 		stopBtn = new JButton();
+		scrollLockBtn = new JToggleButton();
 
 		activeStates = new ArrayList<MUIState>();
 		waitingStates = new ArrayList<MUIState>();
@@ -156,6 +159,9 @@ public class ManticoreRunner {
 					for (MUILogMessage msg : messageList.getMessagesList()) {
 						logText.append(msg.getContent() + System.lineSeparator());
 					}
+					if (!scrollLockBtn.isSelected()) {
+						logText.setCaretPosition(logText.getText().length());
+					}
 				}
 			};
 
@@ -173,6 +179,7 @@ public class ManticoreRunner {
 	public void setLogUIElems(MUILogContentComponent content) {
 		logText = content.logArea;
 		stopBtn = content.stopButton;
+		scrollLockBtn = content.scrollLockButton;
 	}
 
 	/**


### PR DESCRIPTION
Simple change to make the MUI Log auto-scrolling and to add a toggleable scroll lock button (identical to Ghidra's own scroll lock buttons).

Also adds tooltips to both scroll lock and stop buttons.

Fixes #4, figured it'd be a good time to do so since log output finally works + can be more verbose