### PR TITLE
Add StopServer function that kills running Manticore Instances before MUI Server shutdown

### DIFF
--- a/MUI/src/main/grpc/muicore/ManticoreUIGrpc.java
+++ b/MUI/src/main/grpc/muicore/ManticoreUIGrpc.java
@@ -232,6 +232,37 @@ public final class ManticoreUIGrpc {
     return getTargetAddressNativeMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<muicore.MUICore.StopServerRequest,
+      muicore.MUICore.StopServerResponse> getStopServerMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "StopServer",
+      requestType = muicore.MUICore.StopServerRequest.class,
+      responseType = muicore.MUICore.StopServerResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<muicore.MUICore.StopServerRequest,
+      muicore.MUICore.StopServerResponse> getStopServerMethod() {
+    io.grpc.MethodDescriptor<muicore.MUICore.StopServerRequest, muicore.MUICore.StopServerResponse> getStopServerMethod;
+    if ((getStopServerMethod = ManticoreUIGrpc.getStopServerMethod) == null) {
+      synchronized (ManticoreUIGrpc.class) {
+        if ((getStopServerMethod = ManticoreUIGrpc.getStopServerMethod) == null) {
+          ManticoreUIGrpc.getStopServerMethod = getStopServerMethod =
+              io.grpc.MethodDescriptor.<muicore.MUICore.StopServerRequest, muicore.MUICore.StopServerResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "StopServer"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.StopServerRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  muicore.MUICore.StopServerResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new ManticoreUIMethodDescriptorSupplier("StopServer"))
+              .build();
+        }
+      }
+    }
+    return getStopServerMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -329,6 +360,13 @@ public final class ManticoreUIGrpc {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getTargetAddressNativeMethod(), responseObserver);
     }
 
+    /**
+     */
+    public void stopServer(muicore.MUICore.StopServerRequest request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.StopServerResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getStopServerMethod(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -380,6 +418,13 @@ public final class ManticoreUIGrpc {
                 muicore.MUICore.AddressRequest,
                 muicore.MUICore.TargetResponse>(
                   this, METHODID_TARGET_ADDRESS_NATIVE)))
+          .addMethod(
+            getStopServerMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                muicore.MUICore.StopServerRequest,
+                muicore.MUICore.StopServerResponse>(
+                  this, METHODID_STOP_SERVER)))
           .build();
     }
   }
@@ -453,6 +498,14 @@ public final class ManticoreUIGrpc {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getTargetAddressNativeMethod(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     */
+    public void stopServer(muicore.MUICore.StopServerRequest request,
+        io.grpc.stub.StreamObserver<muicore.MUICore.StopServerResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getStopServerMethod(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -516,6 +569,13 @@ public final class ManticoreUIGrpc {
     public muicore.MUICore.TargetResponse targetAddressNative(muicore.MUICore.AddressRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getTargetAddressNativeMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public muicore.MUICore.StopServerResponse stopServer(muicore.MUICore.StopServerRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getStopServerMethod(), getCallOptions(), request);
     }
   }
 
@@ -588,6 +648,14 @@ public final class ManticoreUIGrpc {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getTargetAddressNativeMethod(), getCallOptions()), request);
     }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<muicore.MUICore.StopServerResponse> stopServer(
+        muicore.MUICore.StopServerRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getStopServerMethod(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_START_NATIVE = 0;
@@ -597,6 +665,7 @@ public final class ManticoreUIGrpc {
   private static final int METHODID_GET_MESSAGE_LIST = 4;
   private static final int METHODID_CHECK_MANTICORE_RUNNING = 5;
   private static final int METHODID_TARGET_ADDRESS_NATIVE = 6;
+  private static final int METHODID_STOP_SERVER = 7;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -642,6 +711,10 @@ public final class ManticoreUIGrpc {
         case METHODID_TARGET_ADDRESS_NATIVE:
           serviceImpl.targetAddressNative((muicore.MUICore.AddressRequest) request,
               (io.grpc.stub.StreamObserver<muicore.MUICore.TargetResponse>) responseObserver);
+          break;
+        case METHODID_STOP_SERVER:
+          serviceImpl.stopServer((muicore.MUICore.StopServerRequest) request,
+              (io.grpc.stub.StreamObserver<muicore.MUICore.StopServerResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -711,6 +784,7 @@ public final class ManticoreUIGrpc {
               .addMethod(getGetMessageListMethod())
               .addMethod(getCheckManticoreRunningMethod())
               .addMethod(getTargetAddressNativeMethod())
+              .addMethod(getStopServerMethod())
               .build();
         }
       }

--- a/MUI/src/main/java/mui/MUIPlugin.java
+++ b/MUI/src/main/java/mui/MUIPlugin.java
@@ -33,6 +33,7 @@ import io.grpc.ManagedChannelBuilder;
 import muicore.ManticoreUIGrpc;
 import muicore.ManticoreUIGrpc.ManticoreUIBlockingStub;
 import muicore.ManticoreUIGrpc.ManticoreUIStub;
+import muicore.MUICore.StopServerRequest;
 
 // @formatter:off
 @PluginInfo(
@@ -139,7 +140,7 @@ public class MUIPlugin extends ProgramPlugin {
 
 						@Override
 						public void run() {
-							p.destroy();
+							blockingMUICoreStub.stopServer(StopServerRequest.newBuilder().build());
 						}
 
 					}));

--- a/MUI/src/main/java/muicore/MUICore.java
+++ b/MUI/src/main/java/muicore/MUICore.java
@@ -10214,6 +10214,842 @@ public final class MUICore {
 
   }
 
+  public interface StopServerRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:muicore.StopServerRequest)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code muicore.StopServerRequest}
+   */
+  public static final class StopServerRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:muicore.StopServerRequest)
+      StopServerRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use StopServerRequest.newBuilder() to construct.
+    private StopServerRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private StopServerRequest() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new StopServerRequest();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private StopServerRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return muicore.MUICore.internal_static_muicore_StopServerRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return muicore.MUICore.internal_static_muicore_StopServerRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              muicore.MUICore.StopServerRequest.class, muicore.MUICore.StopServerRequest.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof muicore.MUICore.StopServerRequest)) {
+        return super.equals(obj);
+      }
+      muicore.MUICore.StopServerRequest other = (muicore.MUICore.StopServerRequest) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.StopServerRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.StopServerRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(muicore.MUICore.StopServerRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code muicore.StopServerRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:muicore.StopServerRequest)
+        muicore.MUICore.StopServerRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return muicore.MUICore.internal_static_muicore_StopServerRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return muicore.MUICore.internal_static_muicore_StopServerRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                muicore.MUICore.StopServerRequest.class, muicore.MUICore.StopServerRequest.Builder.class);
+      }
+
+      // Construct using muicore.MUICore.StopServerRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return muicore.MUICore.internal_static_muicore_StopServerRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.StopServerRequest getDefaultInstanceForType() {
+        return muicore.MUICore.StopServerRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.StopServerRequest build() {
+        muicore.MUICore.StopServerRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.StopServerRequest buildPartial() {
+        muicore.MUICore.StopServerRequest result = new muicore.MUICore.StopServerRequest(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof muicore.MUICore.StopServerRequest) {
+          return mergeFrom((muicore.MUICore.StopServerRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(muicore.MUICore.StopServerRequest other) {
+        if (other == muicore.MUICore.StopServerRequest.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        muicore.MUICore.StopServerRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (muicore.MUICore.StopServerRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:muicore.StopServerRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:muicore.StopServerRequest)
+    private static final muicore.MUICore.StopServerRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new muicore.MUICore.StopServerRequest();
+    }
+
+    public static muicore.MUICore.StopServerRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<StopServerRequest>
+        PARSER = new com.google.protobuf.AbstractParser<StopServerRequest>() {
+      @java.lang.Override
+      public StopServerRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new StopServerRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<StopServerRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<StopServerRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public muicore.MUICore.StopServerRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface StopServerResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:muicore.StopServerResponse)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code muicore.StopServerResponse}
+   */
+  public static final class StopServerResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:muicore.StopServerResponse)
+      StopServerResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use StopServerResponse.newBuilder() to construct.
+    private StopServerResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private StopServerResponse() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new StopServerResponse();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private StopServerResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return muicore.MUICore.internal_static_muicore_StopServerResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return muicore.MUICore.internal_static_muicore_StopServerResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              muicore.MUICore.StopServerResponse.class, muicore.MUICore.StopServerResponse.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof muicore.MUICore.StopServerResponse)) {
+        return super.equals(obj);
+      }
+      muicore.MUICore.StopServerResponse other = (muicore.MUICore.StopServerResponse) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.StopServerResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static muicore.MUICore.StopServerResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(muicore.MUICore.StopServerResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code muicore.StopServerResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:muicore.StopServerResponse)
+        muicore.MUICore.StopServerResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return muicore.MUICore.internal_static_muicore_StopServerResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return muicore.MUICore.internal_static_muicore_StopServerResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                muicore.MUICore.StopServerResponse.class, muicore.MUICore.StopServerResponse.Builder.class);
+      }
+
+      // Construct using muicore.MUICore.StopServerResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return muicore.MUICore.internal_static_muicore_StopServerResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.StopServerResponse getDefaultInstanceForType() {
+        return muicore.MUICore.StopServerResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.StopServerResponse build() {
+        muicore.MUICore.StopServerResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public muicore.MUICore.StopServerResponse buildPartial() {
+        muicore.MUICore.StopServerResponse result = new muicore.MUICore.StopServerResponse(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof muicore.MUICore.StopServerResponse) {
+          return mergeFrom((muicore.MUICore.StopServerResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(muicore.MUICore.StopServerResponse other) {
+        if (other == muicore.MUICore.StopServerResponse.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        muicore.MUICore.StopServerResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (muicore.MUICore.StopServerResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:muicore.StopServerResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:muicore.StopServerResponse)
+    private static final muicore.MUICore.StopServerResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new muicore.MUICore.StopServerResponse();
+    }
+
+    public static muicore.MUICore.StopServerResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<StopServerResponse>
+        PARSER = new com.google.protobuf.AbstractParser<StopServerResponse>() {
+      @java.lang.Override
+      public StopServerResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new StopServerResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<StopServerResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<StopServerResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public muicore.MUICore.StopServerResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_muicore_MUILogMessage_descriptor;
   private static final 
@@ -10269,6 +11105,16 @@ public final class MUICore {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_muicore_ManticoreRunningStatus_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_muicore_StopServerRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_muicore_StopServerRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_muicore_StopServerResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_muicore_StopServerResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -10303,20 +11149,23 @@ public final class MUICore {
       "argetType\",\n\nTargetType\022\010\n\004FIND\020\000\022\t\n\005AVO" +
       "ID\020\001\022\t\n\005CLEAR\020\002\"!\n\016TargetResponse\022\017\n\007suc" +
       "cess\030\034 \001(\010\",\n\026ManticoreRunningStatus\022\022\n\n" +
-      "is_running\030\017 \001(\0102\215\004\n\013ManticoreUI\022E\n\013Star" +
-      "tNative\022\030.muicore.NativeArguments\032\032.muic" +
-      "ore.ManticoreInstance\"\000\022?\n\010StartEVM\022\025.mu" +
-      "icore.EVMArguments\032\032.muicore.ManticoreIn" +
-      "stance\"\000\022E\n\tTerminate\022\032.muicore.Manticor" +
-      "eInstance\032\032.muicore.TerminateResponse\"\000\022" +
-      "C\n\014GetStateList\022\032.muicore.ManticoreInsta" +
-      "nce\032\025.muicore.MUIStateList\"\000\022G\n\016GetMessa" +
-      "geList\022\032.muicore.ManticoreInstance\032\027.mui" +
-      "core.MUIMessageList\"\000\022V\n\025CheckManticoreR" +
-      "unning\022\032.muicore.ManticoreInstance\032\037.mui" +
-      "core.ManticoreRunningStatus\"\000\022I\n\023TargetA" +
-      "ddressNative\022\027.muicore.AddressRequest\032\027." +
-      "muicore.TargetResponse\"\000b\006proto3"
+      "is_running\030\017 \001(\010\"\023\n\021StopServerRequest\"\024\n" +
+      "\022StopServerResponse2\326\004\n\013ManticoreUI\022E\n\013S" +
+      "tartNative\022\030.muicore.NativeArguments\032\032.m" +
+      "uicore.ManticoreInstance\"\000\022?\n\010StartEVM\022\025" +
+      ".muicore.EVMArguments\032\032.muicore.Manticor" +
+      "eInstance\"\000\022E\n\tTerminate\022\032.muicore.Manti" +
+      "coreInstance\032\032.muicore.TerminateResponse" +
+      "\"\000\022C\n\014GetStateList\022\032.muicore.ManticoreIn" +
+      "stance\032\025.muicore.MUIStateList\"\000\022G\n\016GetMe" +
+      "ssageList\022\032.muicore.ManticoreInstance\032\027." +
+      "muicore.MUIMessageList\"\000\022V\n\025CheckMantico" +
+      "reRunning\022\032.muicore.ManticoreInstance\032\037." +
+      "muicore.ManticoreRunningStatus\"\000\022I\n\023Targ" +
+      "etAddressNative\022\027.muicore.AddressRequest" +
+      "\032\027.muicore.TargetResponse\"\000\022G\n\nStopServe" +
+      "r\022\032.muicore.StopServerRequest\032\033.muicore." +
+      "StopServerResponse\"\000b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -10388,6 +11237,18 @@ public final class MUICore {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_muicore_ManticoreRunningStatus_descriptor,
         new java.lang.String[] { "IsRunning", });
+    internal_static_muicore_StopServerRequest_descriptor =
+      getDescriptor().getMessageTypes().get(11);
+    internal_static_muicore_StopServerRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_muicore_StopServerRequest_descriptor,
+        new java.lang.String[] { });
+    internal_static_muicore_StopServerResponse_descriptor =
+      getDescriptor().getMessageTypes().get(12);
+    internal_static_muicore_StopServerResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_muicore_StopServerResponse_descriptor,
+        new java.lang.String[] { });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/MUI/src/main/proto/MUICore.proto
+++ b/MUI/src/main/proto/MUICore.proto
@@ -10,6 +10,7 @@ service ManticoreUI {
     rpc GetMessageList(ManticoreInstance) returns (MUIMessageList) {}
     rpc CheckManticoreRunning(ManticoreInstance) returns (ManticoreRunningStatus) {}
     rpc TargetAddressNative(AddressRequest) returns (TargetResponse) {}
+    rpc StopServer(StopServerRequest) returns (StopServerResponse) {}
 }
 
 // LogMessage and StateList message types have "MUI" in their names to distinguish them from those in mserialize
@@ -83,3 +84,7 @@ message TargetResponse {
 message ManticoreRunningStatus {
 	bool is_running = 15;
 }
+
+message StopServerRequest {}
+
+message StopServerResponse {}

--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -10,6 +10,7 @@ service ManticoreUI {
     rpc GetMessageList(ManticoreInstance) returns (MUIMessageList) {}
     rpc CheckManticoreRunning(ManticoreInstance) returns (ManticoreRunningStatus) {}
     rpc TargetAddressNative(AddressRequest) returns (TargetResponse) {}
+    rpc StopServer(StopServerRequest) returns (StopServerResponse) {}
 }
 
 // LogMessage and StateList message types have "MUI" in their names to distinguish them from those in mserialize
@@ -83,3 +84,7 @@ message TargetResponse {
 message ManticoreRunningStatus {
 	bool is_running = 15;
 }
+
+message StopServerRequest {}
+
+message StopServerResponse {}

--- a/MUICore/muicore/MUICore_pb2.py
+++ b/MUICore/muicore/MUICore_pb2.py
@@ -13,172 +13,149 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x15muicore/MUICore.proto\x12\x07muicore" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32".muicore.AddressRequest.TargetType",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x1c \x01(\x08",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\x32\x8d\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse"\x00\x62\x06proto3'
-)
 
 
-_MUILOGMESSAGE = DESCRIPTOR.message_types_by_name["MUILogMessage"]
-_MUIMESSAGELIST = DESCRIPTOR.message_types_by_name["MUIMessageList"]
-_MUISTATE = DESCRIPTOR.message_types_by_name["MUIState"]
-_MUISTATELIST = DESCRIPTOR.message_types_by_name["MUIStateList"]
-_MANTICOREINSTANCE = DESCRIPTOR.message_types_by_name["ManticoreInstance"]
-_TERMINATERESPONSE = DESCRIPTOR.message_types_by_name["TerminateResponse"]
-_NATIVEARGUMENTS = DESCRIPTOR.message_types_by_name["NativeArguments"]
-_EVMARGUMENTS = DESCRIPTOR.message_types_by_name["EVMArguments"]
-_ADDRESSREQUEST = DESCRIPTOR.message_types_by_name["AddressRequest"]
-_TARGETRESPONSE = DESCRIPTOR.message_types_by_name["TargetResponse"]
-_MANTICORERUNNINGSTATUS = DESCRIPTOR.message_types_by_name["ManticoreRunningStatus"]
-_ADDRESSREQUEST_TARGETTYPE = _ADDRESSREQUEST.enum_types_by_name["TargetType"]
-MUILogMessage = _reflection.GeneratedProtocolMessageType(
-    "MUILogMessage",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _MUILOGMESSAGE,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.MUILogMessage)
-    },
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"$\n\x11TerminateResponse\x12\x0f\n\x07success\x18\n \x01(\x08\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"!\n\x0eTargetResponse\x12\x0f\n\x07success\x18\x1c \x01(\x08\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\xd6\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
+
+
+
+_MUILOGMESSAGE = DESCRIPTOR.message_types_by_name['MUILogMessage']
+_MUIMESSAGELIST = DESCRIPTOR.message_types_by_name['MUIMessageList']
+_MUISTATE = DESCRIPTOR.message_types_by_name['MUIState']
+_MUISTATELIST = DESCRIPTOR.message_types_by_name['MUIStateList']
+_MANTICOREINSTANCE = DESCRIPTOR.message_types_by_name['ManticoreInstance']
+_TERMINATERESPONSE = DESCRIPTOR.message_types_by_name['TerminateResponse']
+_NATIVEARGUMENTS = DESCRIPTOR.message_types_by_name['NativeArguments']
+_EVMARGUMENTS = DESCRIPTOR.message_types_by_name['EVMArguments']
+_ADDRESSREQUEST = DESCRIPTOR.message_types_by_name['AddressRequest']
+_TARGETRESPONSE = DESCRIPTOR.message_types_by_name['TargetResponse']
+_MANTICORERUNNINGSTATUS = DESCRIPTOR.message_types_by_name['ManticoreRunningStatus']
+_STOPSERVERREQUEST = DESCRIPTOR.message_types_by_name['StopServerRequest']
+_STOPSERVERRESPONSE = DESCRIPTOR.message_types_by_name['StopServerResponse']
+_ADDRESSREQUEST_TARGETTYPE = _ADDRESSREQUEST.enum_types_by_name['TargetType']
+MUILogMessage = _reflection.GeneratedProtocolMessageType('MUILogMessage', (_message.Message,), {
+  'DESCRIPTOR' : _MUILOGMESSAGE,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.MUILogMessage)
+  })
 _sym_db.RegisterMessage(MUILogMessage)
 
-MUIMessageList = _reflection.GeneratedProtocolMessageType(
-    "MUIMessageList",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _MUIMESSAGELIST,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.MUIMessageList)
-    },
-)
+MUIMessageList = _reflection.GeneratedProtocolMessageType('MUIMessageList', (_message.Message,), {
+  'DESCRIPTOR' : _MUIMESSAGELIST,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.MUIMessageList)
+  })
 _sym_db.RegisterMessage(MUIMessageList)
 
-MUIState = _reflection.GeneratedProtocolMessageType(
-    "MUIState",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _MUISTATE,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.MUIState)
-    },
-)
+MUIState = _reflection.GeneratedProtocolMessageType('MUIState', (_message.Message,), {
+  'DESCRIPTOR' : _MUISTATE,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.MUIState)
+  })
 _sym_db.RegisterMessage(MUIState)
 
-MUIStateList = _reflection.GeneratedProtocolMessageType(
-    "MUIStateList",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _MUISTATELIST,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.MUIStateList)
-    },
-)
+MUIStateList = _reflection.GeneratedProtocolMessageType('MUIStateList', (_message.Message,), {
+  'DESCRIPTOR' : _MUISTATELIST,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.MUIStateList)
+  })
 _sym_db.RegisterMessage(MUIStateList)
 
-ManticoreInstance = _reflection.GeneratedProtocolMessageType(
-    "ManticoreInstance",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _MANTICOREINSTANCE,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.ManticoreInstance)
-    },
-)
+ManticoreInstance = _reflection.GeneratedProtocolMessageType('ManticoreInstance', (_message.Message,), {
+  'DESCRIPTOR' : _MANTICOREINSTANCE,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.ManticoreInstance)
+  })
 _sym_db.RegisterMessage(ManticoreInstance)
 
-TerminateResponse = _reflection.GeneratedProtocolMessageType(
-    "TerminateResponse",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _TERMINATERESPONSE,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.TerminateResponse)
-    },
-)
+TerminateResponse = _reflection.GeneratedProtocolMessageType('TerminateResponse', (_message.Message,), {
+  'DESCRIPTOR' : _TERMINATERESPONSE,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.TerminateResponse)
+  })
 _sym_db.RegisterMessage(TerminateResponse)
 
-NativeArguments = _reflection.GeneratedProtocolMessageType(
-    "NativeArguments",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _NATIVEARGUMENTS,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.NativeArguments)
-    },
-)
+NativeArguments = _reflection.GeneratedProtocolMessageType('NativeArguments', (_message.Message,), {
+  'DESCRIPTOR' : _NATIVEARGUMENTS,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.NativeArguments)
+  })
 _sym_db.RegisterMessage(NativeArguments)
 
-EVMArguments = _reflection.GeneratedProtocolMessageType(
-    "EVMArguments",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _EVMARGUMENTS,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.EVMArguments)
-    },
-)
+EVMArguments = _reflection.GeneratedProtocolMessageType('EVMArguments', (_message.Message,), {
+  'DESCRIPTOR' : _EVMARGUMENTS,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.EVMArguments)
+  })
 _sym_db.RegisterMessage(EVMArguments)
 
-AddressRequest = _reflection.GeneratedProtocolMessageType(
-    "AddressRequest",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _ADDRESSREQUEST,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.AddressRequest)
-    },
-)
+AddressRequest = _reflection.GeneratedProtocolMessageType('AddressRequest', (_message.Message,), {
+  'DESCRIPTOR' : _ADDRESSREQUEST,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.AddressRequest)
+  })
 _sym_db.RegisterMessage(AddressRequest)
 
-TargetResponse = _reflection.GeneratedProtocolMessageType(
-    "TargetResponse",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _TARGETRESPONSE,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.TargetResponse)
-    },
-)
+TargetResponse = _reflection.GeneratedProtocolMessageType('TargetResponse', (_message.Message,), {
+  'DESCRIPTOR' : _TARGETRESPONSE,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.TargetResponse)
+  })
 _sym_db.RegisterMessage(TargetResponse)
 
-ManticoreRunningStatus = _reflection.GeneratedProtocolMessageType(
-    "ManticoreRunningStatus",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _MANTICORERUNNINGSTATUS,
-        "__module__": "muicore.MUICore_pb2"
-        # @@protoc_insertion_point(class_scope:muicore.ManticoreRunningStatus)
-    },
-)
+ManticoreRunningStatus = _reflection.GeneratedProtocolMessageType('ManticoreRunningStatus', (_message.Message,), {
+  'DESCRIPTOR' : _MANTICORERUNNINGSTATUS,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.ManticoreRunningStatus)
+  })
 _sym_db.RegisterMessage(ManticoreRunningStatus)
 
-_MANTICOREUI = DESCRIPTOR.services_by_name["ManticoreUI"]
+StopServerRequest = _reflection.GeneratedProtocolMessageType('StopServerRequest', (_message.Message,), {
+  'DESCRIPTOR' : _STOPSERVERREQUEST,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.StopServerRequest)
+  })
+_sym_db.RegisterMessage(StopServerRequest)
+
+StopServerResponse = _reflection.GeneratedProtocolMessageType('StopServerResponse', (_message.Message,), {
+  'DESCRIPTOR' : _STOPSERVERRESPONSE,
+  '__module__' : 'muicore.MUICore_pb2'
+  # @@protoc_insertion_point(class_scope:muicore.StopServerResponse)
+  })
+_sym_db.RegisterMessage(StopServerResponse)
+
+_MANTICOREUI = DESCRIPTOR.services_by_name['ManticoreUI']
 if _descriptor._USE_C_DESCRIPTORS == False:
 
-    DESCRIPTOR._options = None
-    _MUILOGMESSAGE._serialized_start = 34
-    _MUILOGMESSAGE._serialized_end = 66
-    _MUIMESSAGELIST._serialized_start = 68
-    _MUIMESSAGELIST._serialized_end = 126
-    _MUISTATE._serialized_start = 128
-    _MUISTATE._serialized_end = 156
-    _MUISTATELIST._serialized_start = 159
-    _MUISTATELIST._serialized_end = 387
-    _MANTICOREINSTANCE._serialized_start = 389
-    _MANTICOREINSTANCE._serialized_end = 422
-    _TERMINATERESPONSE._serialized_start = 424
-    _TERMINATERESPONSE._serialized_end = 460
-    _NATIVEARGUMENTS._serialized_start = 463
-    _NATIVEARGUMENTS._serialized_end = 636
-    _EVMARGUMENTS._serialized_start = 639
-    _EVMARGUMENTS._serialized_end = 811
-    _ADDRESSREQUEST._serialized_start = 814
-    _ADDRESSREQUEST._serialized_end = 943
-    _ADDRESSREQUEST_TARGETTYPE._serialized_start = 899
-    _ADDRESSREQUEST_TARGETTYPE._serialized_end = 943
-    _TARGETRESPONSE._serialized_start = 945
-    _TARGETRESPONSE._serialized_end = 978
-    _MANTICORERUNNINGSTATUS._serialized_start = 980
-    _MANTICORERUNNINGSTATUS._serialized_end = 1024
-    _MANTICOREUI._serialized_start = 1027
-    _MANTICOREUI._serialized_end = 1552
+  DESCRIPTOR._options = None
+  _MUILOGMESSAGE._serialized_start=34
+  _MUILOGMESSAGE._serialized_end=66
+  _MUIMESSAGELIST._serialized_start=68
+  _MUIMESSAGELIST._serialized_end=126
+  _MUISTATE._serialized_start=128
+  _MUISTATE._serialized_end=156
+  _MUISTATELIST._serialized_start=159
+  _MUISTATELIST._serialized_end=387
+  _MANTICOREINSTANCE._serialized_start=389
+  _MANTICOREINSTANCE._serialized_end=422
+  _TERMINATERESPONSE._serialized_start=424
+  _TERMINATERESPONSE._serialized_end=460
+  _NATIVEARGUMENTS._serialized_start=463
+  _NATIVEARGUMENTS._serialized_end=636
+  _EVMARGUMENTS._serialized_start=639
+  _EVMARGUMENTS._serialized_end=811
+  _ADDRESSREQUEST._serialized_start=814
+  _ADDRESSREQUEST._serialized_end=943
+  _ADDRESSREQUEST_TARGETTYPE._serialized_start=899
+  _ADDRESSREQUEST_TARGETTYPE._serialized_end=943
+  _TARGETRESPONSE._serialized_start=945
+  _TARGETRESPONSE._serialized_end=978
+  _MANTICORERUNNINGSTATUS._serialized_start=980
+  _MANTICORERUNNINGSTATUS._serialized_end=1024
+  _STOPSERVERREQUEST._serialized_start=1026
+  _STOPSERVERREQUEST._serialized_end=1045
+  _STOPSERVERRESPONSE._serialized_start=1047
+  _STOPSERVERRESPONSE._serialized_end=1067
+  _MANTICOREUI._serialized_start=1070
+  _MANTICOREUI._serialized_end=1668
 # @@protoc_insertion_point(module_scope)

--- a/MUICore/muicore/MUICore_pb2.pyi
+++ b/MUICore/muicore/MUICore_pb2.pyi
@@ -213,3 +213,15 @@ class ManticoreRunningStatus(google.protobuf.message.Message):
         ) -> None: ...
     def ClearField(self, field_name: typing_extensions.Literal["is_running",b"is_running"]) -> None: ...
 global___ManticoreRunningStatus = ManticoreRunningStatus
+
+class StopServerRequest(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    def __init__(self,
+        ) -> None: ...
+global___StopServerRequest = StopServerRequest
+
+class StopServerResponse(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    def __init__(self,
+        ) -> None: ...
+global___StopServerResponse = StopServerResponse

--- a/MUICore/muicore/MUICore_pb2_grpc.py
+++ b/MUICore/muicore/MUICore_pb2_grpc.py
@@ -15,40 +15,45 @@ class ManticoreUIStub(object):
             channel: A grpc.Channel.
         """
         self.StartNative = channel.unary_unary(
-            "/muicore.ManticoreUI/StartNative",
-            request_serializer=muicore_dot_MUICore__pb2.NativeArguments.SerializeToString,
-            response_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-        )
+                '/muicore.ManticoreUI/StartNative',
+                request_serializer=muicore_dot_MUICore__pb2.NativeArguments.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                )
         self.StartEVM = channel.unary_unary(
-            "/muicore.ManticoreUI/StartEVM",
-            request_serializer=muicore_dot_MUICore__pb2.EVMArguments.SerializeToString,
-            response_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-        )
+                '/muicore.ManticoreUI/StartEVM',
+                request_serializer=muicore_dot_MUICore__pb2.EVMArguments.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                )
         self.Terminate = channel.unary_unary(
-            "/muicore.ManticoreUI/Terminate",
-            request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
-            response_deserializer=muicore_dot_MUICore__pb2.TerminateResponse.FromString,
-        )
+                '/muicore.ManticoreUI/Terminate',
+                request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.TerminateResponse.FromString,
+                )
         self.GetStateList = channel.unary_unary(
-            "/muicore.ManticoreUI/GetStateList",
-            request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
-            response_deserializer=muicore_dot_MUICore__pb2.MUIStateList.FromString,
-        )
+                '/muicore.ManticoreUI/GetStateList',
+                request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.MUIStateList.FromString,
+                )
         self.GetMessageList = channel.unary_unary(
-            "/muicore.ManticoreUI/GetMessageList",
-            request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
-            response_deserializer=muicore_dot_MUICore__pb2.MUIMessageList.FromString,
-        )
+                '/muicore.ManticoreUI/GetMessageList',
+                request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.MUIMessageList.FromString,
+                )
         self.CheckManticoreRunning = channel.unary_unary(
-            "/muicore.ManticoreUI/CheckManticoreRunning",
-            request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
-            response_deserializer=muicore_dot_MUICore__pb2.ManticoreRunningStatus.FromString,
-        )
+                '/muicore.ManticoreUI/CheckManticoreRunning',
+                request_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.ManticoreRunningStatus.FromString,
+                )
         self.TargetAddressNative = channel.unary_unary(
-            "/muicore.ManticoreUI/TargetAddressNative",
-            request_serializer=muicore_dot_MUICore__pb2.AddressRequest.SerializeToString,
-            response_deserializer=muicore_dot_MUICore__pb2.TargetResponse.FromString,
-        )
+                '/muicore.ManticoreUI/TargetAddressNative',
+                request_serializer=muicore_dot_MUICore__pb2.AddressRequest.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.TargetResponse.FromString,
+                )
+        self.StopServer = channel.unary_unary(
+                '/muicore.ManticoreUI/StopServer',
+                request_serializer=muicore_dot_MUICore__pb2.StopServerRequest.SerializeToString,
+                response_deserializer=muicore_dot_MUICore__pb2.StopServerResponse.FromString,
+                )
 
 
 class ManticoreUIServicer(object):
@@ -57,293 +62,236 @@ class ManticoreUIServicer(object):
     def StartNative(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def StartEVM(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def Terminate(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def GetStateList(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def GetMessageList(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def CheckManticoreRunning(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
     def TargetAddressNative(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def StopServer(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
 
 
 def add_ManticoreUIServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        "StartNative": grpc.unary_unary_rpc_method_handler(
-            servicer.StartNative,
-            request_deserializer=muicore_dot_MUICore__pb2.NativeArguments.FromString,
-            response_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
-        ),
-        "StartEVM": grpc.unary_unary_rpc_method_handler(
-            servicer.StartEVM,
-            request_deserializer=muicore_dot_MUICore__pb2.EVMArguments.FromString,
-            response_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
-        ),
-        "Terminate": grpc.unary_unary_rpc_method_handler(
-            servicer.Terminate,
-            request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-            response_serializer=muicore_dot_MUICore__pb2.TerminateResponse.SerializeToString,
-        ),
-        "GetStateList": grpc.unary_unary_rpc_method_handler(
-            servicer.GetStateList,
-            request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-            response_serializer=muicore_dot_MUICore__pb2.MUIStateList.SerializeToString,
-        ),
-        "GetMessageList": grpc.unary_unary_rpc_method_handler(
-            servicer.GetMessageList,
-            request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-            response_serializer=muicore_dot_MUICore__pb2.MUIMessageList.SerializeToString,
-        ),
-        "CheckManticoreRunning": grpc.unary_unary_rpc_method_handler(
-            servicer.CheckManticoreRunning,
-            request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-            response_serializer=muicore_dot_MUICore__pb2.ManticoreRunningStatus.SerializeToString,
-        ),
-        "TargetAddressNative": grpc.unary_unary_rpc_method_handler(
-            servicer.TargetAddressNative,
-            request_deserializer=muicore_dot_MUICore__pb2.AddressRequest.FromString,
-            response_serializer=muicore_dot_MUICore__pb2.TargetResponse.SerializeToString,
-        ),
+            'StartNative': grpc.unary_unary_rpc_method_handler(
+                    servicer.StartNative,
+                    request_deserializer=muicore_dot_MUICore__pb2.NativeArguments.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+            ),
+            'StartEVM': grpc.unary_unary_rpc_method_handler(
+                    servicer.StartEVM,
+                    request_deserializer=muicore_dot_MUICore__pb2.EVMArguments.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
+            ),
+            'Terminate': grpc.unary_unary_rpc_method_handler(
+                    servicer.Terminate,
+                    request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.TerminateResponse.SerializeToString,
+            ),
+            'GetStateList': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetStateList,
+                    request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.MUIStateList.SerializeToString,
+            ),
+            'GetMessageList': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetMessageList,
+                    request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.MUIMessageList.SerializeToString,
+            ),
+            'CheckManticoreRunning': grpc.unary_unary_rpc_method_handler(
+                    servicer.CheckManticoreRunning,
+                    request_deserializer=muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.ManticoreRunningStatus.SerializeToString,
+            ),
+            'TargetAddressNative': grpc.unary_unary_rpc_method_handler(
+                    servicer.TargetAddressNative,
+                    request_deserializer=muicore_dot_MUICore__pb2.AddressRequest.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.TargetResponse.SerializeToString,
+            ),
+            'StopServer': grpc.unary_unary_rpc_method_handler(
+                    servicer.StopServer,
+                    request_deserializer=muicore_dot_MUICore__pb2.StopServerRequest.FromString,
+                    response_serializer=muicore_dot_MUICore__pb2.StopServerResponse.SerializeToString,
+            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-        "muicore.ManticoreUI", rpc_method_handlers
-    )
+            'muicore.ManticoreUI', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
-# This class is part of an EXPERIMENTAL API.
+ # This class is part of an EXPERIMENTAL API.
 class ManticoreUI(object):
     """Missing associated documentation comment in .proto file."""
 
     @staticmethod
-    def StartNative(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def StartNative(request,
             target,
-            "/muicore.ManticoreUI/StartNative",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/StartNative',
             muicore_dot_MUICore__pb2.NativeArguments.SerializeToString,
             muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def StartEVM(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def StartEVM(request,
             target,
-            "/muicore.ManticoreUI/StartEVM",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/StartEVM',
             muicore_dot_MUICore__pb2.EVMArguments.SerializeToString,
             muicore_dot_MUICore__pb2.ManticoreInstance.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def Terminate(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def Terminate(request,
             target,
-            "/muicore.ManticoreUI/Terminate",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/Terminate',
             muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
             muicore_dot_MUICore__pb2.TerminateResponse.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def GetStateList(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def GetStateList(request,
             target,
-            "/muicore.ManticoreUI/GetStateList",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/GetStateList',
             muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
             muicore_dot_MUICore__pb2.MUIStateList.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def GetMessageList(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def GetMessageList(request,
             target,
-            "/muicore.ManticoreUI/GetMessageList",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/GetMessageList',
             muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
             muicore_dot_MUICore__pb2.MUIMessageList.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def CheckManticoreRunning(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def CheckManticoreRunning(request,
             target,
-            "/muicore.ManticoreUI/CheckManticoreRunning",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/CheckManticoreRunning',
             muicore_dot_MUICore__pb2.ManticoreInstance.SerializeToString,
             muicore_dot_MUICore__pb2.ManticoreRunningStatus.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
-    def TargetAddressNative(
-        request,
-        target,
-        options=(),
-        channel_credentials=None,
-        call_credentials=None,
-        insecure=False,
-        compression=None,
-        wait_for_ready=None,
-        timeout=None,
-        metadata=None,
-    ):
-        return grpc.experimental.unary_unary(
-            request,
+    def TargetAddressNative(request,
             target,
-            "/muicore.ManticoreUI/TargetAddressNative",
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/TargetAddressNative',
             muicore_dot_MUICore__pb2.AddressRequest.SerializeToString,
             muicore_dot_MUICore__pb2.TargetResponse.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-        )
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def StopServer(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/muicore.ManticoreUI/StopServer',
+            muicore_dot_MUICore__pb2.StopServerRequest.SerializeToString,
+            muicore_dot_MUICore__pb2.StopServerResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -1,11 +1,12 @@
 import argparse
 import logging
 import shutil
+import time
 import uuid
 from concurrent import futures
 from inspect import currentframe, getframeinfo
 from pathlib import Path
-from threading import Thread
+from threading import Event, Thread
 from typing import Dict, Set
 
 import grpc
@@ -59,12 +60,13 @@ class ManticoreWrapper:
 class MUIServicer(ManticoreUIServicer):
     """Provides functionality for the methods set out in the protobuf spec"""
 
-    def __init__(self):
+    def __init__(self, stop_event: Event):
         """Initializes the dict that keeps track of all created manticore instances, as well as avoid/find address set"""
 
         self.manticore_instances: Dict[str, ManticoreWrapper] = {}
         self.avoid: Set[int] = set()
         self.find: Set[int] = set()
+        self.stop_event: Event = stop_event
 
         manticore_logger = logging.getLogger("manticore")
         manticore_logger.parent = None
@@ -181,7 +183,6 @@ class MUIServicer(ManticoreUIServicer):
         self, evm_arguments: EVMArguments, context: _Context
     ) -> ManticoreInstance:
         """Starts a singular Manticore instance to analyze a solidity contract"""
-
         if evm_arguments.contract_path == "":
             raise FileNotFoundError("Contract path not specified!")
         if not Path(evm_arguments.contract_path).is_file():
@@ -354,13 +355,30 @@ class MUIServicer(ManticoreUIServicer):
             )
         )
 
+    def StopServer(
+        self, request: StopServerRequest, context: _Context
+    ) -> StopServerResponse:
+        for mwrapper in self.manticore_instances.values():
+            mwrapper.manticore_object.kill()
+            stime = time.time()
+            while mwrapper.manticore_object.is_running():
+                time.sleep(1)
+                if (time.time() - stime) > 10:
+                    break
+
+        self.stop_event.set()
+        return StopServerResponse()
+
 
 def main():
+    stop_event = Event()
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    add_ManticoreUIServicer_to_server(MUIServicer(), server)
+    add_ManticoreUIServicer_to_server(MUIServicer(stop_event), server)
     server.add_insecure_port("[::]:50010")
     server.start()
-    server.wait_for_termination()
+    stop_event.wait()
+    server.stop(None)
+    print("shutdown gracefully!")
 
 
 if __name__ == "__main__":

--- a/MUICore/setup.py
+++ b/MUICore/setup.py
@@ -29,7 +29,7 @@ class GenerateCommand(Command):
 
 
 native_deps = [
-    "capstone @ git+https://github.com/aquynh/capstone.git@1766485c0c32419e9a17d6ad31f9e218ef4f018f#subdirectory=bindings/python",
+    "capstone==5.0.0rc2",
     "pyelftools",
     "unicorn==1.0.2",
 ]
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "manticore @ git+https://github.com/trailofbits/manticore.git@chess",
         "grpcio",
-        "crytic-compile==0.2.1",
+        "crytic-compile==0.2.2",
     ]
     + native_deps,
     extras_require={"dev": ["grpcio-tools"]},

--- a/MUICore/tests/test_ethereum.py
+++ b/MUICore/tests/test_ethereum.py
@@ -3,6 +3,7 @@ import os
 import time
 import unittest
 import unittest.mock
+import threading
 from inspect import currentframe, getframeinfo
 from pathlib import Path
 from shutil import rmtree, which
@@ -16,7 +17,8 @@ class MUICoreEVMTest(unittest.TestCase):
     def setUp(self):
         self.dirname = str(Path(getframeinfo(currentframe()).filename).resolve().parent)
         self.contract_path = str(self.dirname / Path("contracts") / Path("adder.sol"))
-        self.servicer = mui_server.MUIServicer()
+        self.test_event = threading.Event()
+        self.servicer = mui_server.MUIServicer(self.test_event)
         self.solc_path = str(self.dirname / Path("solc"))
 
     def tearDown(self):
@@ -311,3 +313,19 @@ class MUICoreEVMTest(unittest.TestCase):
                 ManticoreInstance(uuid=uuid4().hex), None
             ).is_running
         )
+
+    def test_stop_server(self):
+        self.servicer.StartEVM(
+            EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
+            None,
+        )
+        self.servicer.StartEVM(
+            EVMArguments(contract_path=self.contract_path, solc_bin=self.solc_path),
+            None,
+        )
+
+        self.servicer.StopServer(StopServerRequest(), None)
+
+        self.assertTrue(self.test_event.is_set())
+        for mwrapper in self.servicer.manticore_instances.values():
+            self.assertFalse(mwrapper.manticore_object.is_running())

--- a/MUICore/tests/test_ethereum.py
+++ b/MUICore/tests/test_ethereum.py
@@ -1,9 +1,9 @@
 import glob
 import os
+import threading
 import time
 import unittest
 import unittest.mock
-import threading
 from inspect import currentframe, getframeinfo
 from pathlib import Path
 from shutil import rmtree, which

--- a/MUICore/tests/test_native.py
+++ b/MUICore/tests/test_native.py
@@ -1,6 +1,7 @@
 import glob
 import time
 import unittest
+import threading
 from inspect import currentframe, getframeinfo
 from pathlib import Path
 from shutil import rmtree
@@ -16,7 +17,8 @@ class MUICoreNativeTest(unittest.TestCase):
         self.binary_path = str(
             self.dirname / Path("binaries") / Path("arguments_linux_amd64")
         )
-        self.servicer = mui_server.MUIServicer()
+        self.test_event = threading.Event()
+        self.servicer = mui_server.MUIServicer(self.test_event)
 
     def tearDown(self):
         for mwrapper in self.servicer.manticore_instances.values():
@@ -277,3 +279,13 @@ class MUICoreNativeTest(unittest.TestCase):
                 ManticoreInstance(uuid=uuid4().hex), None
             ).is_running
         )
+
+    def test_stop_server(self):
+        self.servicer.StartNative(NativeArguments(program_path=self.binary_path), None)
+        self.servicer.StartNative(NativeArguments(program_path=self.binary_path), None)
+
+        self.servicer.StopServer(StopServerRequest(), None)
+
+        self.assertTrue(self.test_event.is_set())
+        for mwrapper in self.servicer.manticore_instances.values():
+            self.assertFalse(mwrapper.manticore_object.is_running())

--- a/MUICore/tests/test_native.py
+++ b/MUICore/tests/test_native.py
@@ -1,7 +1,7 @@
 import glob
+import threading
 import time
 import unittest
-import threading
 from inspect import currentframe, getframeinfo
 from pathlib import Path
 from shutil import rmtree


### PR DESCRIPTION
Inspired by this comment https://github.com/trailofbits/ManticoreUI/pull/61#discussion_r854498344 - adds a StopServer function to the gRPC service that allows a client to call for a graceful gRPC server shutdown, where all Manticore instances are first individually killed before the server is stopped.