### PR TITLE
Server sends over program counter

### DIFF
--- a/MUI/src/main/java/muicore/MUICore.java
+++ b/MUI/src/main/java/muicore/MUICore.java
@@ -1384,6 +1384,12 @@ public final class MUICore {
      * @return The stateId.
      */
     int getStateId();
+
+    /**
+     * <code>uint64 pc = 10;</code>
+     * @return The pc.
+     */
+    long getPc();
   }
   /**
    * Protobuf type {@code muicore.MUIState}
@@ -1435,6 +1441,11 @@ public final class MUICore {
               stateId_ = input.readInt32();
               break;
             }
+            case 80: {
+
+              pc_ = input.readUInt64();
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -1478,6 +1489,17 @@ public final class MUICore {
       return stateId_;
     }
 
+    public static final int PC_FIELD_NUMBER = 10;
+    private long pc_;
+    /**
+     * <code>uint64 pc = 10;</code>
+     * @return The pc.
+     */
+    @java.lang.Override
+    public long getPc() {
+      return pc_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -1495,6 +1517,9 @@ public final class MUICore {
       if (stateId_ != 0) {
         output.writeInt32(3, stateId_);
       }
+      if (pc_ != 0L) {
+        output.writeUInt64(10, pc_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -1507,6 +1532,10 @@ public final class MUICore {
       if (stateId_ != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(3, stateId_);
+      }
+      if (pc_ != 0L) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(10, pc_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1525,6 +1554,8 @@ public final class MUICore {
 
       if (getStateId()
           != other.getStateId()) return false;
+      if (getPc()
+          != other.getPc()) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -1538,6 +1569,9 @@ public final class MUICore {
       hash = (19 * hash) + getDescriptor().hashCode();
       hash = (37 * hash) + STATE_ID_FIELD_NUMBER;
       hash = (53 * hash) + getStateId();
+      hash = (37 * hash) + PC_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+          getPc());
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -1673,6 +1707,8 @@ public final class MUICore {
         super.clear();
         stateId_ = 0;
 
+        pc_ = 0L;
+
         return this;
       }
 
@@ -1700,6 +1736,7 @@ public final class MUICore {
       public muicore.MUICore.MUIState buildPartial() {
         muicore.MUICore.MUIState result = new muicore.MUICore.MUIState(this);
         result.stateId_ = stateId_;
+        result.pc_ = pc_;
         onBuilt();
         return result;
       }
@@ -1750,6 +1787,9 @@ public final class MUICore {
         if (other == muicore.MUICore.MUIState.getDefaultInstance()) return this;
         if (other.getStateId() != 0) {
           setStateId(other.getStateId());
+        }
+        if (other.getPc() != 0L) {
+          setPc(other.getPc());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -1807,6 +1847,37 @@ public final class MUICore {
       public Builder clearStateId() {
         
         stateId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private long pc_ ;
+      /**
+       * <code>uint64 pc = 10;</code>
+       * @return The pc.
+       */
+      @java.lang.Override
+      public long getPc() {
+        return pc_;
+      }
+      /**
+       * <code>uint64 pc = 10;</code>
+       * @param value The pc to set.
+       * @return This builder for chaining.
+       */
+      public Builder setPc(long value) {
+        
+        pc_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>uint64 pc = 10;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearPc() {
+        
+        pc_ = 0L;
         onChanged();
         return this;
       }
@@ -10984,45 +11055,46 @@ public final class MUICore {
     java.lang.String[] descriptorData = {
       "\n\rMUICore.proto\022\007muicore\" \n\rMUILogMessag" +
       "e\022\017\n\007content\030\001 \001(\t\":\n\016MUIMessageList\022(\n\010" +
-      "messages\030\002 \003(\0132\026.muicore.MUILogMessage\"\034" +
-      "\n\010MUIState\022\020\n\010state_id\030\003 \001(\005\"\344\001\n\014MUIStat" +
-      "eList\022(\n\ractive_states\030\004 \003(\0132\021.muicore.M" +
-      "UIState\022)\n\016waiting_states\030\005 \003(\0132\021.muicor" +
-      "e.MUIState\022(\n\rforked_states\030\006 \003(\0132\021.muic" +
-      "ore.MUIState\022)\n\016errored_states\030\007 \003(\0132\021.m" +
-      "uicore.MUIState\022*\n\017complete_states\030\010 \003(\013" +
-      "2\021.muicore.MUIState\"!\n\021ManticoreInstance" +
-      "\022\014\n\004uuid\030\t \001(\t\"\023\n\021TerminateResponse\"\255\001\n\017" +
-      "NativeArguments\022\024\n\014program_path\030\013 \001(\t\022\023\n" +
-      "\013binary_args\030\020 \003(\t\022\014\n\004envp\030\021 \003(\t\022\026\n\016symb" +
-      "olic_files\030\022 \003(\t\022\026\n\016concrete_start\030\023 \001(\t" +
-      "\022\022\n\nstdin_size\030\024 \001(\t\022\035\n\025additional_mcore" +
-      "_args\030\025 \001(\t\"\254\001\n\014EVMArguments\022\025\n\rcontract" +
-      "_path\030\014 \001(\t\022\025\n\rcontract_name\030\r \001(\t\022\020\n\010so" +
-      "lc_bin\030\016 \001(\t\022\020\n\010tx_limit\030\026 \001(\t\022\022\n\ntx_acc" +
-      "ount\030\027 \001(\t\022\034\n\024detectors_to_exclude\030\030 \003(\t" +
-      "\022\030\n\020additional_flags\030\031 \001(\t\"\201\001\n\016AddressRe" +
-      "quest\022\017\n\007address\030\032 \001(\004\0220\n\004type\030\033 \001(\0162\".m" +
-      "uicore.AddressRequest.TargetType\",\n\nTarg" +
-      "etType\022\010\n\004FIND\020\000\022\t\n\005AVOID\020\001\022\t\n\005CLEAR\020\002\"\020" +
-      "\n\016TargetResponse\",\n\026ManticoreRunningStat" +
-      "us\022\022\n\nis_running\030\017 \001(\010\"\023\n\021StopServerRequ" +
-      "est\"\024\n\022StopServerResponse2\326\004\n\013ManticoreU" +
-      "I\022E\n\013StartNative\022\030.muicore.NativeArgumen" +
-      "ts\032\032.muicore.ManticoreInstance\"\000\022?\n\010Star" +
-      "tEVM\022\025.muicore.EVMArguments\032\032.muicore.Ma" +
-      "nticoreInstance\"\000\022E\n\tTerminate\022\032.muicore" +
-      ".ManticoreInstance\032\032.muicore.TerminateRe" +
-      "sponse\"\000\022C\n\014GetStateList\022\032.muicore.Manti" +
-      "coreInstance\032\025.muicore.MUIStateList\"\000\022G\n" +
-      "\016GetMessageList\022\032.muicore.ManticoreInsta" +
-      "nce\032\027.muicore.MUIMessageList\"\000\022V\n\025CheckM" +
-      "anticoreRunning\022\032.muicore.ManticoreInsta" +
-      "nce\032\037.muicore.ManticoreRunningStatus\"\000\022I" +
-      "\n\023TargetAddressNative\022\027.muicore.AddressR" +
-      "equest\032\027.muicore.TargetResponse\"\000\022G\n\nSto" +
-      "pServer\022\032.muicore.StopServerRequest\032\033.mu" +
-      "icore.StopServerResponse\"\000b\006proto3"
+      "messages\030\002 \003(\0132\026.muicore.MUILogMessage\"(" +
+      "\n\010MUIState\022\020\n\010state_id\030\003 \001(\005\022\n\n\002pc\030\n \001(\004" +
+      "\"\344\001\n\014MUIStateList\022(\n\ractive_states\030\004 \003(\013" +
+      "2\021.muicore.MUIState\022)\n\016waiting_states\030\005 " +
+      "\003(\0132\021.muicore.MUIState\022(\n\rforked_states\030" +
+      "\006 \003(\0132\021.muicore.MUIState\022)\n\016errored_stat" +
+      "es\030\007 \003(\0132\021.muicore.MUIState\022*\n\017complete_" +
+      "states\030\010 \003(\0132\021.muicore.MUIState\"!\n\021Manti" +
+      "coreInstance\022\014\n\004uuid\030\t \001(\t\"\023\n\021TerminateR" +
+      "esponse\"\255\001\n\017NativeArguments\022\024\n\014program_p" +
+      "ath\030\013 \001(\t\022\023\n\013binary_args\030\020 \003(\t\022\014\n\004envp\030\021" +
+      " \003(\t\022\026\n\016symbolic_files\030\022 \003(\t\022\026\n\016concrete" +
+      "_start\030\023 \001(\t\022\022\n\nstdin_size\030\024 \001(\t\022\035\n\025addi" +
+      "tional_mcore_args\030\025 \001(\t\"\254\001\n\014EVMArguments" +
+      "\022\025\n\rcontract_path\030\014 \001(\t\022\025\n\rcontract_name" +
+      "\030\r \001(\t\022\020\n\010solc_bin\030\016 \001(\t\022\020\n\010tx_limit\030\026 \001" +
+      "(\t\022\022\n\ntx_account\030\027 \001(\t\022\034\n\024detectors_to_e" +
+      "xclude\030\030 \003(\t\022\030\n\020additional_flags\030\031 \001(\t\"\201" +
+      "\001\n\016AddressRequest\022\017\n\007address\030\032 \001(\004\0220\n\004ty" +
+      "pe\030\033 \001(\0162\".muicore.AddressRequest.Target" +
+      "Type\",\n\nTargetType\022\010\n\004FIND\020\000\022\t\n\005AVOID\020\001\022" +
+      "\t\n\005CLEAR\020\002\"\020\n\016TargetResponse\",\n\026Manticor" +
+      "eRunningStatus\022\022\n\nis_running\030\017 \001(\010\"\023\n\021St" +
+      "opServerRequest\"\024\n\022StopServerResponse2\326\004" +
+      "\n\013ManticoreUI\022E\n\013StartNative\022\030.muicore.N" +
+      "ativeArguments\032\032.muicore.ManticoreInstan" +
+      "ce\"\000\022?\n\010StartEVM\022\025.muicore.EVMArguments\032" +
+      "\032.muicore.ManticoreInstance\"\000\022E\n\tTermina" +
+      "te\022\032.muicore.ManticoreInstance\032\032.muicore" +
+      ".TerminateResponse\"\000\022C\n\014GetStateList\022\032.m" +
+      "uicore.ManticoreInstance\032\025.muicore.MUISt" +
+      "ateList\"\000\022G\n\016GetMessageList\022\032.muicore.Ma" +
+      "nticoreInstance\032\027.muicore.MUIMessageList" +
+      "\"\000\022V\n\025CheckManticoreRunning\022\032.muicore.Ma" +
+      "nticoreInstance\032\037.muicore.ManticoreRunni" +
+      "ngStatus\"\000\022I\n\023TargetAddressNative\022\027.muic" +
+      "ore.AddressRequest\032\027.muicore.TargetRespo" +
+      "nse\"\000\022G\n\nStopServer\022\032.muicore.StopServer" +
+      "Request\032\033.muicore.StopServerResponse\"\000b\006" +
+      "proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -11045,7 +11117,7 @@ public final class MUICore {
     internal_static_muicore_MUIState_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_muicore_MUIState_descriptor,
-        new java.lang.String[] { "StateId", });
+        new java.lang.String[] { "StateId", "Pc", });
     internal_static_muicore_MUIStateList_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_muicore_MUIStateList_fieldAccessorTable = new

--- a/MUI/src/main/proto/MUICore.proto
+++ b/MUI/src/main/proto/MUICore.proto
@@ -25,7 +25,7 @@ message MUIMessageList{
 
 message MUIState {
 	int32 state_id = 3;
-    uint64 pc = 10
+    uint64 pc = 10;
 }
 
 message MUIStateList{

--- a/MUI/src/main/proto/MUICore.proto
+++ b/MUI/src/main/proto/MUICore.proto
@@ -25,6 +25,7 @@ message MUIMessageList{
 
 message MUIState {
 	int32 state_id = 3;
+    uint64 pc = 10
 }
 
 message MUIStateList{

--- a/MUI/src/main/proto/MUICore.proto
+++ b/MUI/src/main/proto/MUICore.proto
@@ -16,7 +16,7 @@ service ManticoreUI {
 // LogMessage and StateList message types have "MUI" in their names to distinguish them from those in mserialize
 
 message MUILogMessage{ 
-	string content = 1;
+    string content = 1;
 }
 
 message MUIMessageList{
@@ -24,18 +24,18 @@ message MUIMessageList{
 }
 
 message MUIState {
-	int32 state_id = 3;
+    int32 state_id = 3;
     uint64 pc = 10;
 }
 
 message MUIStateList{
 
-	// state categories in MUI - based on manticore enums StateStatus and StateList
-	repeated MUIState active_states = 4;
-	repeated MUIState waiting_states = 5;
-	repeated MUIState forked_states = 6;
-	repeated MUIState errored_states = 7;
-	repeated MUIState complete_states = 8;
+    // state categories in MUI - based on manticore enums StateStatus and StateList
+    repeated MUIState active_states = 4;
+    repeated MUIState waiting_states = 5;
+    repeated MUIState forked_states = 6;
+    repeated MUIState errored_states = 7;
+    repeated MUIState complete_states = 8;
 }
 
 message ManticoreInstance {
@@ -46,7 +46,7 @@ message TerminateResponse {}
 
 message NativeArguments {
     string program_path = 11;
-    repeated string binary_args = 16;	
+    repeated string binary_args = 16;    
     repeated string envp = 17;
     repeated string symbolic_files = 18;
     string concrete_start = 19;
@@ -55,13 +55,13 @@ message NativeArguments {
 }
 
 message EVMArguments {
-	string contract_path = 12;
-	string contract_name = 13;
-	string solc_bin = 14;
-	string tx_limit = 22;
-	string tx_account = 23;
-	repeated string detectors_to_exclude = 24;
-	string additional_flags = 25;
+    string contract_path = 12;
+    string contract_name = 13;
+    string solc_bin = 14;
+    string tx_limit = 22;
+    string tx_account = 23;
+    repeated string detectors_to_exclude = 24;
+    string additional_flags = 25;
 }
 
 message AddressRequest {
@@ -79,7 +79,7 @@ message AddressRequest {
 message TargetResponse {}
 
 message ManticoreRunningStatus {
-	bool is_running = 15;
+    bool is_running = 15;
 }
 
 message StopServerRequest {}

--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -25,7 +25,7 @@ message MUIMessageList{
 
 message MUIState {
 	int32 state_id = 3;
-    uint64 pc = 10
+    uint64 pc = 10;
 }
 
 message MUIStateList{

--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -25,6 +25,7 @@ message MUIMessageList{
 
 message MUIState {
 	int32 state_id = 3;
+    uint64 pc = 10
 }
 
 message MUIStateList{

--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -16,7 +16,7 @@ service ManticoreUI {
 // LogMessage and StateList message types have "MUI" in their names to distinguish them from those in mserialize
 
 message MUILogMessage{ 
-	string content = 1;
+    string content = 1;
 }
 
 message MUIMessageList{
@@ -24,18 +24,18 @@ message MUIMessageList{
 }
 
 message MUIState {
-	int32 state_id = 3;
+    int32 state_id = 3;
     uint64 pc = 10;
 }
 
 message MUIStateList{
 
-	// state categories in MUI - based on manticore enums StateStatus and StateList
-	repeated MUIState active_states = 4;
-	repeated MUIState waiting_states = 5;
-	repeated MUIState forked_states = 6;
-	repeated MUIState errored_states = 7;
-	repeated MUIState complete_states = 8;
+    // state categories in MUI - based on manticore enums StateStatus and StateList
+    repeated MUIState active_states = 4;
+    repeated MUIState waiting_states = 5;
+    repeated MUIState forked_states = 6;
+    repeated MUIState errored_states = 7;
+    repeated MUIState complete_states = 8;
 }
 
 message ManticoreInstance {
@@ -46,7 +46,7 @@ message TerminateResponse {}
 
 message NativeArguments {
     string program_path = 11;
-    repeated string binary_args = 16;	
+    repeated string binary_args = 16;    
     repeated string envp = 17;
     repeated string symbolic_files = 18;
     string concrete_start = 19;
@@ -55,13 +55,13 @@ message NativeArguments {
 }
 
 message EVMArguments {
-	string contract_path = 12;
-	string contract_name = 13;
-	string solc_bin = 14;
-	string tx_limit = 22;
-	string tx_account = 23;
-	repeated string detectors_to_exclude = 24;
-	string additional_flags = 25;
+    string contract_path = 12;
+    string contract_name = 13;
+    string solc_bin = 14;
+    string tx_limit = 22;
+    string tx_account = 23;
+    repeated string detectors_to_exclude = 24;
+    string additional_flags = 25;
 }
 
 message AddressRequest {
@@ -79,7 +79,7 @@ message AddressRequest {
 message TargetResponse {}
 
 message ManticoreRunningStatus {
-	bool is_running = 15;
+    bool is_running = 15;
 }
 
 message StopServerRequest {}

--- a/MUICore/muicore/MUICore_pb2.py
+++ b/MUICore/muicore/MUICore_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"\x1c\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"\x10\n\x0eTargetResponse\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\xd6\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"(\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\x12\n\n\x02pc\x18\n \x01(\x04\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"\x10\n\x0eTargetResponse\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\xd6\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
 
 
 
@@ -132,29 +132,29 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _MUIMESSAGELIST._serialized_start=68
   _MUIMESSAGELIST._serialized_end=126
   _MUISTATE._serialized_start=128
-  _MUISTATE._serialized_end=156
-  _MUISTATELIST._serialized_start=159
-  _MUISTATELIST._serialized_end=387
-  _MANTICOREINSTANCE._serialized_start=389
-  _MANTICOREINSTANCE._serialized_end=422
-  _TERMINATERESPONSE._serialized_start=424
-  _TERMINATERESPONSE._serialized_end=443
-  _NATIVEARGUMENTS._serialized_start=446
-  _NATIVEARGUMENTS._serialized_end=619
-  _EVMARGUMENTS._serialized_start=622
-  _EVMARGUMENTS._serialized_end=794
-  _ADDRESSREQUEST._serialized_start=797
-  _ADDRESSREQUEST._serialized_end=926
-  _ADDRESSREQUEST_TARGETTYPE._serialized_start=882
-  _ADDRESSREQUEST_TARGETTYPE._serialized_end=926
-  _TARGETRESPONSE._serialized_start=928
-  _TARGETRESPONSE._serialized_end=944
-  _MANTICORERUNNINGSTATUS._serialized_start=946
-  _MANTICORERUNNINGSTATUS._serialized_end=990
-  _STOPSERVERREQUEST._serialized_start=992
-  _STOPSERVERREQUEST._serialized_end=1011
-  _STOPSERVERRESPONSE._serialized_start=1013
-  _STOPSERVERRESPONSE._serialized_end=1033
-  _MANTICOREUI._serialized_start=1036
-  _MANTICOREUI._serialized_end=1634
+  _MUISTATE._serialized_end=168
+  _MUISTATELIST._serialized_start=171
+  _MUISTATELIST._serialized_end=399
+  _MANTICOREINSTANCE._serialized_start=401
+  _MANTICOREINSTANCE._serialized_end=434
+  _TERMINATERESPONSE._serialized_start=436
+  _TERMINATERESPONSE._serialized_end=455
+  _NATIVEARGUMENTS._serialized_start=458
+  _NATIVEARGUMENTS._serialized_end=631
+  _EVMARGUMENTS._serialized_start=634
+  _EVMARGUMENTS._serialized_end=806
+  _ADDRESSREQUEST._serialized_start=809
+  _ADDRESSREQUEST._serialized_end=938
+  _ADDRESSREQUEST_TARGETTYPE._serialized_start=894
+  _ADDRESSREQUEST_TARGETTYPE._serialized_end=938
+  _TARGETRESPONSE._serialized_start=940
+  _TARGETRESPONSE._serialized_end=956
+  _MANTICORERUNNINGSTATUS._serialized_start=958
+  _MANTICORERUNNINGSTATUS._serialized_end=1002
+  _STOPSERVERREQUEST._serialized_start=1004
+  _STOPSERVERREQUEST._serialized_end=1023
+  _STOPSERVERRESPONSE._serialized_start=1025
+  _STOPSERVERRESPONSE._serialized_end=1045
+  _MANTICOREUI._serialized_start=1048
+  _MANTICOREUI._serialized_end=1646
 # @@protoc_insertion_point(module_scope)

--- a/MUICore/muicore/MUICore_pb2.pyi
+++ b/MUICore/muicore/MUICore_pb2.pyi
@@ -41,12 +41,15 @@ global___MUIMessageList = MUIMessageList
 class MUIState(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
     STATE_ID_FIELD_NUMBER: builtins.int
+    PC_FIELD_NUMBER: builtins.int
     state_id: builtins.int
+    pc: builtins.int
     def __init__(self,
         *,
         state_id: builtins.int = ...,
+        pc: builtins.int = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["state_id",b"state_id"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["pc",b"pc","state_id",b"state_id"]) -> None: ...
 global___MUIState = MUIState
 
 class MUIStateList(google.protobuf.message.Message):

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -333,7 +333,14 @@ class MUIServicer(ManticoreUIServicer):
         states = m.introspect()
 
         for state_id, state_desc in states.items():
-            s = MUIState(state_id=state_id)
+
+            if isinstance(state_desc.pc, int):
+                s = MUIState(state_id=state_id, pc=state_desc.pc)
+            elif isinstance(state_desc.last_pc, int):
+                s = MUIState(state_id=state_id, pc=state_desc.last_pc)
+            else:
+                s = MUIState(state_id=state_id)
+
             if state_desc.status == StateStatus.running:
                 active_states.append(s)
             elif state_desc.status in (


### PR DESCRIPTION
Tiny PR which updates the protobuf spec and server to send over a state's `pc` or `last_pc` if present. This is just a server update - Ghidra plugin doesn't support jumping to address yet as of this PR.