### PR TITLE
CheckManticoreRunning considers finalize operation / test case generation

### DIFF
--- a/MUI/src/main/java/mui/ManticoreRunner.java
+++ b/MUI/src/main/java/mui/ManticoreRunner.java
@@ -77,7 +77,7 @@ public class ManticoreRunner {
 
 			@Override
 			public void onError(Throwable arg0) {
-				Msg.error(this, nativeArgs);
+				logText.append(arg0.getMessage() + System.lineSeparator());
 			}
 
 			@Override

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -396,11 +396,7 @@ class MUIServicer(ManticoreUIServicer):
 
         m_wrapper = self.manticore_instances[mcore_instance.uuid]
 
-        return ManticoreRunningStatus(
-            is_running=(
-                m_wrapper.manticore_object.is_running() and m_wrapper.thread.is_alive()
-            )
-        )
+        return ManticoreRunningStatus(is_running=(m_wrapper.thread.is_alive()))
 
     def StopServer(
         self, request: StopServerRequest, context: _Context
@@ -409,7 +405,7 @@ class MUIServicer(ManticoreUIServicer):
         for mwrapper in self.manticore_instances.values():
             mwrapper.manticore_object.kill()
             stime = time.time()
-            while mwrapper.manticore_object.is_running():
+            while mwrapper.thread.is_alive():
                 time.sleep(1)
                 if (time.time() - stime) > 10:
                     to_warn = True

--- a/MUICore/requirements-dev.txt
+++ b/MUICore/requirements-dev.txt
@@ -3,3 +3,5 @@ isort==5.10.1
 mypy==0.942
 types-setuptools==57.4.12
 mypy-protobuf==3.2.0
+grpcio==0.46.3
+grpcio-tools==0.46.3

--- a/MUICore/requirements-dev.txt
+++ b/MUICore/requirements-dev.txt
@@ -3,5 +3,5 @@ isort==5.10.1
 mypy==0.942
 types-setuptools==57.4.12
 mypy-protobuf==3.2.0
-grpcio==0.46.3
-grpcio-tools==0.46.3
+grpcio==1.46.3
+grpcio-tools==1.46.3

--- a/MUICore/setup.py
+++ b/MUICore/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         # manticore from upstream chess branch with fixes not yet in master
         "manticore @ git+https://github.com/trailofbits/manticore.git@634b6a4cdc295c93027b1dbe5037e574cf76200b",
-        "grpcio",
+        "grpcio==1.46.3",
         "crytic-compile==0.2.2",
     ]
     + native_deps,

--- a/MUICore/tests/test_ethereum.py
+++ b/MUICore/tests/test_ethereum.py
@@ -309,9 +309,9 @@ class MUICoreEVMTest(unittest.TestCase):
 
         stime = time.time()
         while mwrapper.thread.is_alive():
-            if (time.time() - stime) > 15:
+            if (time.time() - stime) > 45:
                 self.fail(
-                    f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
+                    f"Manticore instance {mcore_instance.uuid} failed to stop running and finish generating reports before timeout"
                 )
             time.sleep(1)
 

--- a/MUICore/tests/test_ethereum.py
+++ b/MUICore/tests/test_ethereum.py
@@ -29,9 +29,9 @@ class MUICoreEVMTest(unittest.TestCase):
         for mwrapper in self.servicer.manticore_instances.values():
             mwrapper.manticore_object.kill()
             stime = time.time()
-            while mwrapper.manticore_object.is_running():
+            while mwrapper.thread.is_alive():
                 time.sleep(1)
-                if (time.time() - stime) > 10:
+                if (time.time() - stime) > 15:
                     break
 
     @classmethod
@@ -308,8 +308,8 @@ class MUICoreEVMTest(unittest.TestCase):
         mwrapper.manticore_object.kill()
 
         stime = time.time()
-        while mwrapper.manticore_object.is_running():
-            if (time.time() - stime) > 10:
+        while mwrapper.thread.is_alive():
+            if (time.time() - stime) > 15:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
                 )

--- a/MUICore/tests/test_native.py
+++ b/MUICore/tests/test_native.py
@@ -273,9 +273,9 @@ class MUICoreNativeTest(unittest.TestCase):
 
         stime = time.time()
         while mwrapper.thread.is_alive:
-            if (time.time() - stime) > 15:
+            if (time.time() - stime) > 45:
                 self.fail(
-                    f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
+                    f"Manticore instance {mcore_instance.uuid} failed to stop running and finish generating reports before timeout"
                 )
             time.sleep(1)
 

--- a/MUICore/tests/test_native.py
+++ b/MUICore/tests/test_native.py
@@ -272,7 +272,7 @@ class MUICoreNativeTest(unittest.TestCase):
         mwrapper.manticore_object.kill()
 
         stime = time.time()
-        while mwrapper.thread.is_alive:
+        while mwrapper.thread.is_alive():
             if (time.time() - stime) > 45:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running and finish generating reports before timeout"

--- a/MUICore/tests/test_native.py
+++ b/MUICore/tests/test_native.py
@@ -28,9 +28,9 @@ class MUICoreNativeTest(unittest.TestCase):
         for mwrapper in self.servicer.manticore_instances.values():
             mwrapper.manticore_object.kill()
             stime = time.time()
-            while mwrapper.manticore_object.is_running():
+            while mwrapper.thread.is_alive():
                 time.sleep(1)
-                if (time.time() - stime) > 10:
+                if (time.time() - stime) > 15:
                     break
 
     @classmethod
@@ -272,8 +272,8 @@ class MUICoreNativeTest(unittest.TestCase):
         mwrapper.manticore_object.kill()
 
         stime = time.time()
-        while mwrapper.manticore_object.is_running():
-            if (time.time() - stime) > 10:
+        while mwrapper.thread.is_alive:
+            if (time.time() - stime) > 15:
                 self.fail(
                     f"Manticore instance {mcore_instance.uuid} failed to stop running before timeout"
                 )


### PR DESCRIPTION
Fixes issue described in #30 and resolves weird behaviour seen in https://github.com/trailofbits/ManticoreUI/pull/68

Also, the final state of a Manticore instance's state list is now saved after `run()` is complete/terminated and before `finalize()`, since `finalize()` will indiscriminately destroy all states. This allows for a frontend client to be able to fetch an instance's state list after `finalize()` has been called but retain the correct number of `forked`, `complete`, and `errored` states (otherwise, all states will have a `StateStatus.Destroyed` and fall under `forked`)