### PR TITLE
Server sends over state parent

### DIFF
--- a/MUICore/muicore/MUICore.proto
+++ b/MUICore/muicore/MUICore.proto
@@ -26,6 +26,7 @@ message MUIMessageList{
 message MUIState {
     int32 state_id = 3;
     uint64 pc = 10;
+    int32 parent_id = 28;
 }
 
 message MUIStateList{

--- a/MUICore/muicore/MUICore_pb2.py
+++ b/MUICore/muicore/MUICore_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\"(\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\x12\n\n\x02pc\x18\n \x01(\x04\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"\x10\n\x0eTargetResponse\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\xd6\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15muicore/MUICore.proto\x12\x07muicore\" \n\rMUILogMessage\x12\x0f\n\x07\x63ontent\x18\x01 \x01(\t\":\n\x0eMUIMessageList\x12(\n\x08messages\x18\x02 \x03(\x0b\x32\x16.muicore.MUILogMessage\";\n\x08MUIState\x12\x10\n\x08state_id\x18\x03 \x01(\x05\x12\n\n\x02pc\x18\n \x01(\x04\x12\x11\n\tparent_id\x18\x1c \x01(\x05\"\xe4\x01\n\x0cMUIStateList\x12(\n\ractive_states\x18\x04 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0ewaiting_states\x18\x05 \x03(\x0b\x32\x11.muicore.MUIState\x12(\n\rforked_states\x18\x06 \x03(\x0b\x32\x11.muicore.MUIState\x12)\n\x0e\x65rrored_states\x18\x07 \x03(\x0b\x32\x11.muicore.MUIState\x12*\n\x0f\x63omplete_states\x18\x08 \x03(\x0b\x32\x11.muicore.MUIState\"!\n\x11ManticoreInstance\x12\x0c\n\x04uuid\x18\t \x01(\t\"\x13\n\x11TerminateResponse\"\xad\x01\n\x0fNativeArguments\x12\x14\n\x0cprogram_path\x18\x0b \x01(\t\x12\x13\n\x0b\x62inary_args\x18\x10 \x03(\t\x12\x0c\n\x04\x65nvp\x18\x11 \x03(\t\x12\x16\n\x0esymbolic_files\x18\x12 \x03(\t\x12\x16\n\x0e\x63oncrete_start\x18\x13 \x01(\t\x12\x12\n\nstdin_size\x18\x14 \x01(\t\x12\x1d\n\x15\x61\x64\x64itional_mcore_args\x18\x15 \x01(\t\"\xac\x01\n\x0c\x45VMArguments\x12\x15\n\rcontract_path\x18\x0c \x01(\t\x12\x15\n\rcontract_name\x18\r \x01(\t\x12\x10\n\x08solc_bin\x18\x0e \x01(\t\x12\x10\n\x08tx_limit\x18\x16 \x01(\t\x12\x12\n\ntx_account\x18\x17 \x01(\t\x12\x1c\n\x14\x64\x65tectors_to_exclude\x18\x18 \x03(\t\x12\x18\n\x10\x61\x64\x64itional_flags\x18\x19 \x01(\t\"\x81\x01\n\x0e\x41\x64\x64ressRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x1a \x01(\x04\x12\x30\n\x04type\x18\x1b \x01(\x0e\x32\".muicore.AddressRequest.TargetType\",\n\nTargetType\x12\x08\n\x04\x46IND\x10\x00\x12\t\n\x05\x41VOID\x10\x01\x12\t\n\x05\x43LEAR\x10\x02\"\x10\n\x0eTargetResponse\",\n\x16ManticoreRunningStatus\x12\x12\n\nis_running\x18\x0f \x01(\x08\"\x13\n\x11StopServerRequest\"\x14\n\x12StopServerResponse2\xd6\x04\n\x0bManticoreUI\x12\x45\n\x0bStartNative\x12\x18.muicore.NativeArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12?\n\x08StartEVM\x12\x15.muicore.EVMArguments\x1a\x1a.muicore.ManticoreInstance\"\x00\x12\x45\n\tTerminate\x12\x1a.muicore.ManticoreInstance\x1a\x1a.muicore.TerminateResponse\"\x00\x12\x43\n\x0cGetStateList\x12\x1a.muicore.ManticoreInstance\x1a\x15.muicore.MUIStateList\"\x00\x12G\n\x0eGetMessageList\x12\x1a.muicore.ManticoreInstance\x1a\x17.muicore.MUIMessageList\"\x00\x12V\n\x15\x43heckManticoreRunning\x12\x1a.muicore.ManticoreInstance\x1a\x1f.muicore.ManticoreRunningStatus\"\x00\x12I\n\x13TargetAddressNative\x12\x17.muicore.AddressRequest\x1a\x17.muicore.TargetResponse\"\x00\x12G\n\nStopServer\x12\x1a.muicore.StopServerRequest\x1a\x1b.muicore.StopServerResponse\"\x00\x62\x06proto3')
 
 
 
@@ -132,29 +132,29 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _MUIMESSAGELIST._serialized_start=68
   _MUIMESSAGELIST._serialized_end=126
   _MUISTATE._serialized_start=128
-  _MUISTATE._serialized_end=168
-  _MUISTATELIST._serialized_start=171
-  _MUISTATELIST._serialized_end=399
-  _MANTICOREINSTANCE._serialized_start=401
-  _MANTICOREINSTANCE._serialized_end=434
-  _TERMINATERESPONSE._serialized_start=436
-  _TERMINATERESPONSE._serialized_end=455
-  _NATIVEARGUMENTS._serialized_start=458
-  _NATIVEARGUMENTS._serialized_end=631
-  _EVMARGUMENTS._serialized_start=634
-  _EVMARGUMENTS._serialized_end=806
-  _ADDRESSREQUEST._serialized_start=809
-  _ADDRESSREQUEST._serialized_end=938
-  _ADDRESSREQUEST_TARGETTYPE._serialized_start=894
-  _ADDRESSREQUEST_TARGETTYPE._serialized_end=938
-  _TARGETRESPONSE._serialized_start=940
-  _TARGETRESPONSE._serialized_end=956
-  _MANTICORERUNNINGSTATUS._serialized_start=958
-  _MANTICORERUNNINGSTATUS._serialized_end=1002
-  _STOPSERVERREQUEST._serialized_start=1004
-  _STOPSERVERREQUEST._serialized_end=1023
-  _STOPSERVERRESPONSE._serialized_start=1025
-  _STOPSERVERRESPONSE._serialized_end=1045
-  _MANTICOREUI._serialized_start=1048
-  _MANTICOREUI._serialized_end=1646
+  _MUISTATE._serialized_end=187
+  _MUISTATELIST._serialized_start=190
+  _MUISTATELIST._serialized_end=418
+  _MANTICOREINSTANCE._serialized_start=420
+  _MANTICOREINSTANCE._serialized_end=453
+  _TERMINATERESPONSE._serialized_start=455
+  _TERMINATERESPONSE._serialized_end=474
+  _NATIVEARGUMENTS._serialized_start=477
+  _NATIVEARGUMENTS._serialized_end=650
+  _EVMARGUMENTS._serialized_start=653
+  _EVMARGUMENTS._serialized_end=825
+  _ADDRESSREQUEST._serialized_start=828
+  _ADDRESSREQUEST._serialized_end=957
+  _ADDRESSREQUEST_TARGETTYPE._serialized_start=913
+  _ADDRESSREQUEST_TARGETTYPE._serialized_end=957
+  _TARGETRESPONSE._serialized_start=959
+  _TARGETRESPONSE._serialized_end=975
+  _MANTICORERUNNINGSTATUS._serialized_start=977
+  _MANTICORERUNNINGSTATUS._serialized_end=1021
+  _STOPSERVERREQUEST._serialized_start=1023
+  _STOPSERVERREQUEST._serialized_end=1042
+  _STOPSERVERRESPONSE._serialized_start=1044
+  _STOPSERVERRESPONSE._serialized_end=1064
+  _MANTICOREUI._serialized_start=1067
+  _MANTICOREUI._serialized_end=1665
 # @@protoc_insertion_point(module_scope)

--- a/MUICore/muicore/MUICore_pb2.pyi
+++ b/MUICore/muicore/MUICore_pb2.pyi
@@ -42,14 +42,17 @@ class MUIState(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
     STATE_ID_FIELD_NUMBER: builtins.int
     PC_FIELD_NUMBER: builtins.int
+    PARENT_ID_FIELD_NUMBER: builtins.int
     state_id: builtins.int
     pc: builtins.int
+    parent_id: builtins.int
     def __init__(self,
         *,
         state_id: builtins.int = ...,
         pc: builtins.int = ...,
+        parent_id: builtins.int = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["pc",b"pc","state_id",b"state_id"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["parent_id",b"parent_id","pc",b"pc","state_id",b"state_id"]) -> None: ...
 global___MUIState = MUIState
 
 class MUIStateList(google.protobuf.message.Message):

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -358,12 +358,19 @@ class MUIServicer(ManticoreUIServicer):
 
         for state_id, state_desc in states.items():
 
+            state_args = {"state_id": state_id}
+
             if isinstance(state_desc.pc, int):
-                s = MUIState(state_id=state_id, pc=state_desc.pc)
+                state_args["pc"] = state_desc.pc
             elif isinstance(state_desc.last_pc, int):
-                s = MUIState(state_id=state_id, pc=state_desc.last_pc)
-            else:
-                s = MUIState(state_id=state_id)
+                state_args["pc"] = state_desc.last_pc
+
+            if isinstance(state_desc.parent, int):
+                state_args["parent_id"] = state_desc.parent
+
+            s = MUIState(**state_args)
+
+            print(s)
 
             if state_desc.status == StateStatus.running:
                 active_states.append(s)

--- a/MUICore/muicore/mui_server.py
+++ b/MUICore/muicore/mui_server.py
@@ -370,8 +370,6 @@ class MUIServicer(ManticoreUIServicer):
 
             s = MUIState(**state_args)
 
-            print(s)
-
             if state_desc.status == StateStatus.running:
                 active_states.append(s)
             elif state_desc.status in (


### PR DESCRIPTION
Small PR (similar to the addition of program counter #29) which sends over the parent id (if applicable) as part of a state's info when GetStateList is called.

Used in support of upcoming PR (sitting on branch https://github.com/trailofbits/ManticoreUI/tree/muicore/state-graph-support for now) which allows the Binja plugin to display and support all State Graph functionality on the Server Integration branch 