### PR TITLE
Ghidra plugin can set custom/global hooks

### DIFF
--- a/MUI/src/main/java/mui/MUIHookListComponent.java
+++ b/MUI/src/main/java/mui/MUIHookListComponent.java
@@ -19,11 +19,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 
-import ghidra.program.model.address.Address;
-import ghidra.util.Msg;
-
 import muicore.MUICore.Hook;
-import muicore.MUICore.Hook.Builder;
 import muicore.MUICore.Hook.HookType;
 
 public class MUIHookListComponent extends JPanel {
@@ -86,10 +82,12 @@ public class MUIHookListComponent extends JPanel {
 					switch (rightClickedHook.type) {
 						case FIND:
 						case AVOID:
-							MUIPlugin.popup.unsetColor(new Address());
+							MUIPlugin.popup.unsetColor(rightClickedHook.address);
 						case CUSTOM:
 						case GLOBAL:
 							removeHookIfExists(rightClickedHook.name, rightClickedHook.type);
+						default:
+							break;
 					}
 				}
 			}
@@ -100,13 +98,13 @@ public class MUIHookListComponent extends JPanel {
 			@Override
 			public void mouseClicked(java.awt.event.MouseEvent e) {
 				if (SwingUtilities.isRightMouseButton(e)) {
-					TreePath path = hookListTree.getPathForLocation(e.getX(), e.getY());
+					TreePath path = hookListTree.getClosestPathForLocation(e.getX(), e.getY());
 					if (path != null) {
 						DefaultMutableTreeNode node =
 							(DefaultMutableTreeNode) path.getLastPathComponent();
-						if (node.getUserObject() instanceof Hook) {
+						if (node.getUserObject() instanceof MUIHookUserObject) {
 							rightClickedHook = (MUIHookUserObject) node.getUserObject();
-
+							hookListPopupMenu.show(hookListTree, e.getX(), e.getY());
 						}
 					}
 				}

--- a/MUI/src/main/java/mui/MUIHookUserObject.java
+++ b/MUI/src/main/java/mui/MUIHookUserObject.java
@@ -4,23 +4,49 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
+import ghidra.program.model.address.Address;
+import muicore.MUICore.Hook;
 import muicore.MUICore.Hook.HookType;
+import muicore.MUICore.Hook.Builder;
 
 public class MUIHookUserObject {
 	public HookType type;
 	public String name;
+	public Address address;
 	public String func_text;
 
-	public MUIHookUserObject(HookType type, String name, String func_text) {
+	public MUIHookUserObject(HookType type, Address address, String func_text) {
 		this.type = type;
-		this.name = (name != null) ? name
-				: "Global " + ZonedDateTime.now(ZoneId.systemDefault())
-						.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+		this.name = address.toString();
+		this.address = address;
 		this.func_text = func_text;
 	}
 
-	@Override
-	public String toString() {
-		return name;
+	public MUIHookUserObject(HookType type, String func_text) {
+		this.type = type;
+		this.name = "Global " + ZonedDateTime.now(ZoneId.systemDefault())
+				.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+		this.func_text = func_text;
+	}
+
+	public Hook toMUIHook() {
+		Builder b = Hook.newBuilder().setType(type);
+		switch (type) {
+			case FIND:
+			case AVOID:
+				b.setAddress(
+					Long.parseLong(address.toString(), 16));
+				break;
+			case CUSTOM:
+				b.setAddress(
+					Long.parseLong(address.toString(), 16));
+			case GLOBAL:
+				b.setFuncText(func_text);
+				break;
+			default:
+				break;
+		}
+		return b.build();
+
 	}
 }

--- a/MUI/src/main/java/mui/MUIHookUserObject.java
+++ b/MUI/src/main/java/mui/MUIHookUserObject.java
@@ -1,0 +1,26 @@
+package mui;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import muicore.MUICore.Hook.HookType;
+
+public class MUIHookUserObject {
+	public HookType type;
+	public String name;
+	public String func_text;
+
+	public MUIHookUserObject(HookType type, String name, String func_text) {
+		this.type = type;
+		this.name = (name != null) ? name
+				: "Global " + ZonedDateTime.now(ZoneId.systemDefault())
+						.format(DateTimeFormatter.ofPattern("HH:mm:ss"));
+		this.func_text = func_text;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/MUI/src/main/java/mui/MUIPlugin.java
+++ b/MUI/src/main/java/mui/MUIPlugin.java
@@ -118,7 +118,7 @@ public class MUIPlugin extends ProgramPlugin {
 				if (result == JOptionPane.OK_OPTION) {
 					String func_text = textArea.getText();
 					setup.setupHookList
-							.addHook(new MUIHookUserObject(HookType.GLOBAL, null, func_text));
+							.addHook(new MUIHookUserObject(HookType.GLOBAL, func_text));
 				}
 			}
 

--- a/MUI/src/main/java/mui/MUIPlugin.java
+++ b/MUI/src/main/java/mui/MUIPlugin.java
@@ -15,6 +15,9 @@
  */
 package mui;
 
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
 import javax.swing.SwingWorker;
 
 import docking.ActionContext;
@@ -28,12 +31,14 @@ import ghidra.framework.ApplicationConfiguration;
 import ghidra.framework.plugintool.*;
 import ghidra.framework.plugintool.util.PluginStatus;
 import ghidra.program.model.listing.Program;
+import ghidra.util.Msg;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import muicore.ManticoreUIGrpc;
 import muicore.ManticoreUIGrpc.ManticoreUIBlockingStub;
 import muicore.ManticoreUIGrpc.ManticoreUIStub;
 import muicore.MUICore.StopServerRequest;
+import muicore.MUICore.Hook.HookType;
 
 // @formatter:off
 @PluginInfo(
@@ -58,6 +63,7 @@ public class MUIPlugin extends ProgramPlugin {
 	private DockingAction showSetup;
 	private DockingAction showLog;
 	private DockingAction showStateList;
+	private DockingAction showCreateGlobalHookDialog;
 
 	/**
 	 * The main extension constructor, initializes the plugin's components and sets up the "MUI" MenuBar tab.
@@ -100,13 +106,34 @@ public class MUIPlugin extends ProgramPlugin {
 
 		};
 
+		showCreateGlobalHookDialog = new DockingAction("Create Global Hook", pluginName) {
+
+			@Override
+			public void actionPerformed(ActionContext context) {
+				JTextArea textArea =
+					new JTextArea("global m\ndef hook(state):\n    pass\nm.hook(None)(hook)");
+				JScrollPane scrollPane = new JScrollPane(textArea);
+				int result = JOptionPane.showConfirmDialog(null, scrollPane, "Create Global Hook",
+					JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+				if (result == JOptionPane.OK_OPTION) {
+					String func_text = textArea.getText();
+					setup.setupHookList
+							.addHook(new MUIHookUserObject(HookType.GLOBAL, null, func_text));
+				}
+			}
+
+		};
+
 		showSetup.setMenuBarData(new MenuData(new String[] { "MUI", "Run Manticore" }));
 		showLog.setMenuBarData(new MenuData(new String[] { "MUI", "Show Log" }));
 		showStateList.setMenuBarData(new MenuData(new String[] { "MUI", "Show State List" }));
+		showCreateGlobalHookDialog
+				.setMenuBarData(new MenuData(new String[] { "MUI", "Create Global Hook" }));
 
 		tool.addAction(showSetup);
 		tool.addAction(showLog);
 		tool.addAction(showStateList);
+		tool.addAction(showCreateGlobalHookDialog);
 	}
 
 	/**

--- a/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -75,7 +75,7 @@ public class MUIPopupMenu extends ListingContextAction {
 					}
 					else {
 						MUIPlugin.setup.setupHookList.addHook(
-							new MUIHookUserObject(HookType.FIND, selectedAddr.toString(), null));
+							new MUIHookUserObject(HookType.FIND, selectedAddr, null));
 						setColor(selectedAddr, Color.GREEN);
 					}
 
@@ -104,7 +104,7 @@ public class MUIPopupMenu extends ListingContextAction {
 					}
 					else {
 						MUIPlugin.setup.setupHookList.addHook(
-							new MUIHookUserObject(HookType.AVOID, selectedAddr.toString(), null));
+							new MUIHookUserObject(HookType.AVOID, selectedAddr, null));
 						setColor(selectedAddr, Color.RED);
 					}
 
@@ -132,7 +132,7 @@ public class MUIPopupMenu extends ListingContextAction {
 					if (result == JOptionPane.OK_OPTION) {
 						String func_text = textArea.getText();
 						MUIPlugin.setup.setupHookList.addHook(new MUIHookUserObject(HookType.CUSTOM,
-							selectedAddr.toString(), func_text));
+							selectedAddr, func_text));
 					}
 				}
 			};

--- a/MUI/src/main/java/mui/MUIPopupMenu.java
+++ b/MUI/src/main/java/mui/MUIPopupMenu.java
@@ -3,6 +3,10 @@ package mui;
 import java.awt.Color;
 import java.util.HashSet;
 
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
 import docking.action.MenuData;
 import ghidra.app.context.ListingActionContext;
 import ghidra.app.context.ListingContextAction;
@@ -62,14 +66,16 @@ public class MUIPopupMenu extends ListingContextAction {
 				protected void actionPerformed(ListingActionContext context) {
 					Address selectedAddr = context.getLocation().getAddress();
 
-					MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr, HookType.AVOID);
+					MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr.toString(),
+						HookType.AVOID);
 
-					if (MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr,
+					if (MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr.toString(),
 						HookType.FIND)) {
 						unsetColor(selectedAddr);
 					}
 					else {
-						MUIPlugin.setup.setupHookList.addHook(selectedAddr, HookType.FIND);
+						MUIPlugin.setup.setupHookList.addHook(
+							new MUIHookUserObject(HookType.FIND, selectedAddr.toString(), null));
 						setColor(selectedAddr, Color.GREEN);
 					}
 
@@ -89,14 +95,16 @@ public class MUIPopupMenu extends ListingContextAction {
 				protected void actionPerformed(ListingActionContext context) {
 					Address selectedAddr = context.getLocation().getAddress();
 
-					MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr, HookType.FIND);
+					MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr.toString(),
+						HookType.FIND);
 
-					if (MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr,
+					if (MUIPlugin.setup.setupHookList.removeHookIfExists(selectedAddr.toString(),
 						HookType.AVOID)) {
 						unsetColor(selectedAddr);
 					}
 					else {
-						MUIPlugin.setup.setupHookList.addHook(selectedAddr, HookType.AVOID);
+						MUIPlugin.setup.setupHookList.addHook(
+							new MUIHookUserObject(HookType.AVOID, selectedAddr.toString(), null));
 						setColor(selectedAddr, Color.RED);
 					}
 
@@ -110,6 +118,30 @@ public class MUIPopupMenu extends ListingContextAction {
 
 		pluginTool.addAction(avoidInstruction);
 
+		ListingContextAction addCustomHookAtInstruction =
+			new ListingContextAction("Add Custom Hook at Instruction", "MUI") {
+				@Override
+				protected void actionPerformed(ListingActionContext context) {
+					Address selectedAddr = context.getLocation().getAddress();
+					JTextArea textArea = new JTextArea(
+						"global m, addr\ndef hook(state):\n    pass\nm.hook(addr)(hook)");
+					JScrollPane scrollPane = new JScrollPane(textArea);
+					int result = JOptionPane.showConfirmDialog(null, scrollPane,
+						"Create Custom Hook at " + selectedAddr.toString(),
+						JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
+					if (result == JOptionPane.OK_OPTION) {
+						String func_text = textArea.getText();
+						MUIPlugin.setup.setupHookList.addHook(new MUIHookUserObject(HookType.CUSTOM,
+							selectedAddr.toString(), func_text));
+					}
+				}
+			};
+		addCustomHookAtInstruction.setPopupMenuData(new MenuData(new String[] {
+			"MUI",
+			"Add Custom Hook at Instruction",
+		}));
+
+		pluginTool.addAction(addCustomHookAtInstruction);
 	}
 
 	/** 


### PR DESCRIPTION
Adds UI elements to the Ghidra plugin that allows custom/global hooks to be set, and for all hooks to be deletable via the Hook List component. Directly mimics UI of the Binja plugin.

Specifically, Global Hooks can be created from the Plugins/MUI menu, and Custom Hooks can be created on the context menu (alongside Find/Avoid hooks). A dialog with pre-populated template hook code will pop up